### PR TITLE
example project generator: use properties view

### DIFF
--- a/org.strategoxt.imp.generator/src/sdf2imp/project/create-example-trans.str
+++ b/org.strategoxt.imp.generator/src/sdf2imp/project/create-example-trans.str
@@ -33,6 +33,7 @@ imports
 	lib/runtime/types/-
 	lib/runtime/task/-
 	lib/runtime/analysis/-
+	lib/runtime/editor/-
 	names
 	check
 	generate
@@ -60,7 +61,13 @@ rules // Editor services
 	// Returns "hover help" information for a particular node in the editor.
 	// For references, this rule is invoked using the resolved term.
 	editor-hover:
-		(target, position, ast, path, project-path) -> <fail>
+		(target, position, ast, path, project-path) ->
+			<get-editor-properties(pp-{sdf-name}-string |<language>, project-path);properties-to-html>target
+
+	// Gathers the properties for the properties view.
+	editor-properties:
+		(target, position, ast, path, project-path) ->
+			<get-editor-properties(pp-{sdf-name}-string |<language>, project-path)>target
 
 	// Completes an identifier when the user presses control-space
 	// (the completion identifier in the AST provides additional context information)

--- a/org.strategoxt.imp.generator/src/sdf2imp/services/create-views-descriptor.str
+++ b/org.strategoxt.imp.generator/src/sdf2imp/services/create-views-descriptor.str
@@ -17,6 +17,8 @@ views
   
   outline view: outline
     expand to level: 3
+    
+	properties view: editor-properties
 }
    ,
      not(file-exists)


### PR DESCRIPTION
Let the default project use the properties view.

Note: runtime libraries must be updated before being able to build this newly generated project.
@see https://github.com/metaborg/runtime-libraries/pull/6
