### PR TITLE
Allow retrieval of fragments within a region

### DIFF
--- a/org.metaborg.core/src/main/java/org/metaborg/core/tracing/ITracingService.java
+++ b/org.metaborg.core/src/main/java/org/metaborg/core/tracing/ITracingService.java
@@ -77,4 +77,49 @@ public interface ITracingService<P extends IParseUnit, A extends IAnalyzeUnit, T
      *         fragment to outermost (root) fragment. An empty iterable is returned when no fragments could be found.
      */
     Iterable<F> fragments(T result, ISourceRegion region);
+
+    /**
+     * Finds all fragments contained within the given region.
+     * 
+     * This only returns the outermost fragments that are contained in the region. Their children are trivially also
+     * contained in the region and will not be added separately to the returned result.
+     * 
+     * @param result
+     *            Parsed result to get fragments from.
+     * @param region
+     *            Region inside the result to get fragments for.
+     * @return Fragments contained within the given region. An empty iterable is returned when no fragments could be
+     *         found.
+     */
+    Iterable<F> fragmentsWithin(P result, ISourceRegion region);
+
+    /**
+     * Finds all fragments contained within the given region.
+     * 
+     * This only returns the outermost fragments that are contained in the region. Their children are trivially also
+     * contained in the region and will not be added separately to the returned result.
+     * 
+     * @param result
+     *            Analyzed result to get fragments from.
+     * @param region
+     *            Region inside the result to get fragments for.
+     * @return Fragments contained within the given region. An empty iterable is returned when no fragments could be
+     *         found.
+     */
+    Iterable<F> fragmentsWithin(A result, ISourceRegion region);
+
+    /**
+     * Finds all fragments contained within the given region.
+     * 
+     * This only returns the outermost fragments that are contained in the region. Their children are trivially also
+     * contained in the region and will not be added separately to the returned result.
+     * 
+     * @param result
+     *            Transformed result to get fragments from.
+     * @param region
+     *            Region inside the result to get fragments for.
+     * @return Fragments contained within the given region. An empty iterable is returned when no fragments could be
+     *         found.
+     */
+    Iterable<F> fragmentsWithin(T result, ISourceRegion region);
 }


### PR DESCRIPTION
The tracing service allowed retrieval of fragments that contained a region.
Now we can also retrieve fragments that are contained by a region.

Required for the new SPT with test fixtures.