### PR TITLE
New sdf2table

### DIFF
--- a/org.metaborg.core/src/main/java/org/metaborg/core/build/CommonPaths.java
+++ b/org.metaborg.core/src/main/java/org/metaborg/core/build/CommonPaths.java
@@ -136,7 +136,7 @@ public class CommonPaths {
     public FileObject syntaxDir() {
         return resolve(root, "syntax");
     }
-
+    
     /**
      * @param languageName
      *            Name of the language.
@@ -152,6 +152,13 @@ public class CommonPaths {
     public FileObject syntaxSrcGenDir() {
         return resolve(srcGenDir(), "syntax");
     }
+    
+    /**
+     * @return Normalized syntax directory. Contains the SDF3 normalized files.
+     */
+    public FileObject syntaxNormDir() {
+        return resolve(syntaxSrcGenDir(), "normalized");
+    }
 
     /**
      * @param languageName
@@ -160,6 +167,15 @@ public class CommonPaths {
      */
     public FileObject syntaxSrcGenMainFile(String languageName) {
         return resolve(syntaxSrcGenDir(), languageName + ".sdf");
+    }
+    
+    /**
+     * @param languageName
+     *            Name of the language.
+     * @return Main generated SDF2 file, generated from main SDF3 file.
+     */
+    public FileObject syntaxSrcGenMainNormFile(String languageName) {
+        return resolve(syntaxNormDir(), languageName + "-norm.aterm");
     }
 
     /**

--- a/org.metaborg.spoofax.meta.core/pom.xml
+++ b/org.metaborg.spoofax.meta.core/pom.xml
@@ -52,6 +52,11 @@
       <artifactId>make-permissive</artifactId>
       <version>${metaborg-version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.metaborg</groupId>
+      <artifactId>sdf2table.core</artifactId>
+      <version>${metaborg-version}</version>
+    </dependency>
 
     <dependency>
       <groupId>build.pluto</groupId>

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/SpoofaxExtensionModule.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/SpoofaxExtensionModule.java
@@ -2,6 +2,7 @@ package org.metaborg.spoofax.meta.core;
 
 import org.metaborg.spoofax.core.Spoofax;
 import org.metaborg.spoofax.core.SpoofaxModule;
+import org.metaborg.spoofax.meta.core.stratego.primitives.CheckSdf2TablePrimitive;
 import org.metaborg.spoofax.meta.core.stratego.primitives.LanguageSpecNamePrimitive;
 import org.spoofax.interpreter.library.AbstractPrimitive;
 
@@ -23,5 +24,6 @@ public class SpoofaxExtensionModule extends AbstractModule {
         final Multibinder<AbstractPrimitive> spoofaxPrimitiveLibrary =
             Multibinder.newSetBinder(binder(), AbstractPrimitive.class, Names.named("SpoofaxPrimitiveLibrary"));
         spoofaxPrimitiveLibrary.addBinding().to(LanguageSpecNamePrimitive.class).in(Singleton.class);
+        spoofaxPrimitiveLibrary.addBinding().to(CheckSdf2TablePrimitive.class).in(Singleton.class);
     }
 }

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/SpoofaxMetaModule.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/SpoofaxMetaModule.java
@@ -19,6 +19,7 @@ import org.metaborg.spoofax.meta.core.config.SpoofaxLanguageSpecConfigBuilder;
 import org.metaborg.spoofax.meta.core.config.SpoofaxLanguageSpecConfigService;
 import org.metaborg.spoofax.meta.core.project.ISpoofaxLanguageSpecService;
 import org.metaborg.spoofax.meta.core.project.SpoofaxLanguageSpecService;
+import org.metaborg.spoofax.meta.core.stratego.primitives.CheckSdf2TablePrimitive;
 import org.metaborg.spoofax.meta.core.stratego.primitives.LanguageSpecNamePrimitive;
 
 import com.google.inject.Singleton;
@@ -38,6 +39,7 @@ public class SpoofaxMetaModule extends MetaborgMetaModule {
 
         // Static injections for SpoofaxExtensionModule bindings.
         requestStaticInjection(LanguageSpecNamePrimitive.class);
+        requestStaticInjection(CheckSdf2TablePrimitive.class);
     }
 
     protected void bindAnt() {

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/build/LanguageSpecBuilder.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/build/LanguageSpecBuilder.java
@@ -31,6 +31,7 @@ import org.metaborg.spoofax.core.build.ISpoofaxBuildOutput;
 import org.metaborg.spoofax.core.processing.ISpoofaxProcessorRunner;
 import org.metaborg.spoofax.meta.core.config.ISpoofaxLanguageSpecConfig;
 import org.metaborg.spoofax.meta.core.config.LanguageSpecBuildPhase;
+import org.metaborg.spoofax.meta.core.config.Sdf2tableVersion;
 import org.metaborg.spoofax.meta.core.config.SdfVersion;
 import org.metaborg.spoofax.meta.core.config.StrategoFormat;
 import org.metaborg.spoofax.meta.core.generator.GeneratorSettings;
@@ -311,6 +312,7 @@ public class LanguageSpecBuilder {
 
         final FileObject sdfFileCandidate;
         final SdfVersion sdfVersion = config.sdfVersion();
+        final Sdf2tableVersion sdf2tableVersion = config.sdf2tableVersion();
         switch(sdfVersion) {
             case sdf2:
                 sdfFileCandidate = paths.syntaxMainFile(sdfModule);
@@ -417,8 +419,8 @@ public class LanguageSpecBuilder {
         final Arguments strjArgs = config.strArgs();
 
         return new GenerateSourcesBuilder.Input(context, config.identifier().id, sdfModule, sdfFile, sdfVersion,
-            sdfExternalDef, packSdfIncludePaths, packSdfArgs, sdfMetaModule, sdfMetaFile, strFile, strStratPkg,
-            strJavaStratPkg, strJavaStratFile, strFormat, strExternalJar, strExternalJarFlags, strjIncludeDirs,
+            sdf2tableVersion, sdfExternalDef, packSdfIncludePaths, packSdfArgs, sdfMetaModule, sdfMetaFile, strFile, 
+            strStratPkg, strJavaStratPkg, strJavaStratFile, strFormat, strExternalJar, strExternalJarFlags, strjIncludeDirs,
             strjArgs);
     }
 

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/config/ISpoofaxLanguageSpecConfig.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/config/ISpoofaxLanguageSpecConfig.java
@@ -20,6 +20,13 @@ public interface ISpoofaxLanguageSpecConfig extends ILanguageSpecConfig {
      * @return Sdf version to use.
      */
     SdfVersion sdfVersion();
+    
+    /**
+     * Gets the sdf2table version to use.
+     *
+     * @return sdf2table version to use.
+     */
+    Sdf2tableVersion sdf2tableVersion();
 
     /**
      * Gets the external def.

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/config/ISpoofaxLanguageSpecConfigBuilder.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/config/ISpoofaxLanguageSpecConfigBuilder.java
@@ -107,6 +107,15 @@ public interface ISpoofaxLanguageSpecConfigBuilder extends ILanguageSpecConfigBu
      * @return This builder.
      */
     ISpoofaxLanguageSpecConfigBuilder withSdfVersion(SdfVersion sdfVersion);
+    
+    /**
+     * Sets the sdf2table version.
+     *
+     * @param sdf2tableVersion
+     *            The sdf2table version.
+     * @return This builder.
+     */
+    ISpoofaxLanguageSpecConfigBuilder withSdf2tableVersion(Sdf2tableVersion sdf2tableVersion);
 
     /**
      * Sets the external def.

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/config/Sdf2tableVersion.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/config/Sdf2tableVersion.java
@@ -1,0 +1,5 @@
+package org.metaborg.spoofax.meta.core.config;
+
+public enum Sdf2tableVersion {
+    c, java
+}

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/config/SpoofaxLanguageSpecConfig.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/config/SpoofaxLanguageSpecConfig.java
@@ -31,6 +31,7 @@ public class SpoofaxLanguageSpecConfig extends LanguageSpecConfig implements ISp
 
     private static final String PROP_SDF = "language.sdf";
     private static final String PROP_SDF_VERSION = PROP_SDF + ".version";
+    private static final String PROP_SDF2TABLE_VERSION = PROP_SDF + ".sdf2table";
     private static final String PROP_SDF_EXTERNAL_DEF = PROP_SDF + ".externalDef";
     private static final String PROP_SDF_ARGS = PROP_SDF + ".args";
 
@@ -56,9 +57,9 @@ public class SpoofaxLanguageSpecConfig extends LanguageSpecConfig implements ISp
         @Nullable Boolean typesmart, @Nullable Collection<LanguageContributionIdentifier> langContribs,
         @Nullable Collection<IGenerateConfig> generates, @Nullable Collection<IExportConfig> exports,
         @Nullable String metaborgVersion, @Nullable Collection<String> pardonedLanguages,
-        @Nullable Boolean useBuildSystemSpec, @Nullable SdfVersion sdfVersion, @Nullable String externalDef,
-        @Nullable Arguments sdfArgs, @Nullable StrategoFormat format, @Nullable String externalJar,
-        @Nullable String externalJarFlags, @Nullable Arguments strategoArgs,
+        @Nullable Boolean useBuildSystemSpec, @Nullable SdfVersion sdfVersion, @Nullable Sdf2tableVersion sdf2tableVersion,
+        @Nullable String externalDef, @Nullable Arguments sdfArgs, @Nullable StrategoFormat format, 
+        @Nullable String externalJar, @Nullable String externalJarFlags, @Nullable Arguments strategoArgs,
         @Nullable Collection<IBuildStepConfig> buildSteps) {
         super(config, metaborgVersion, id, name, compileDeps, sourceDeps, javaDeps, typesmart, langContribs, generates,
             exports, pardonedLanguages, useBuildSystemSpec);
@@ -66,6 +67,9 @@ public class SpoofaxLanguageSpecConfig extends LanguageSpecConfig implements ISp
         if(sdfVersion != null) {
             config.setProperty(PROP_SDF_VERSION, sdfVersion);
         }
+        if(sdf2tableVersion != null) {
+            config.setProperty(PROP_SDF2TABLE_VERSION, sdf2tableVersion);
+        }        
         if(externalDef != null) {
             config.setProperty(PROP_SDF_EXTERNAL_DEF, externalDef);
         }
@@ -105,6 +109,11 @@ public class SpoofaxLanguageSpecConfig extends LanguageSpecConfig implements ISp
     @Override public SdfVersion sdfVersion() {
         final String value = this.config.getString(PROP_SDF_VERSION);
         return value != null ? SdfVersion.valueOf(value) : SdfVersion.sdf3;
+    }
+    
+    @Override public Sdf2tableVersion sdf2tableVersion() {
+        final String value = this.config.getString(PROP_SDF2TABLE_VERSION);
+        return value != null ? Sdf2tableVersion.valueOf(value) : Sdf2tableVersion.c;
     }
 
     @Nullable public String sdfExternalDef() {

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/config/SpoofaxLanguageSpecConfigBuilder.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/config/SpoofaxLanguageSpecConfigBuilder.java
@@ -25,6 +25,7 @@ import com.google.inject.Inject;
 public class SpoofaxLanguageSpecConfigBuilder extends LanguageSpecConfigBuilder
     implements ISpoofaxLanguageSpecConfigBuilder {
     protected @Nullable SdfVersion sdfVersion;
+    protected @Nullable Sdf2tableVersion sdf2tableVersion;
     protected @Nullable String sdfExternalDef;
     protected @Nullable Arguments sdfArgs;
     protected @Nullable StrategoFormat strFormat;
@@ -45,14 +46,15 @@ public class SpoofaxLanguageSpecConfigBuilder extends LanguageSpecConfigBuilder
         }
         final SpoofaxLanguageSpecConfig config =
             new SpoofaxLanguageSpecConfig(configuration, identifier, name, compileDeps, sourceDeps, javaDeps, typesmart,
-                langContribs, generates, exports, metaborgVersion, pardonedLanguages, useBuildSystemSpec, sdfVersion,
-                sdfExternalDef, sdfArgs, strFormat, strExternalJar, strExternalJarFlags, strArgs, buildSteps);
+                langContribs, generates, exports, metaborgVersion, pardonedLanguages, useBuildSystemSpec, sdfVersion, 
+                sdf2tableVersion, sdfExternalDef, sdfArgs, strFormat, strExternalJar, strExternalJarFlags, strArgs, buildSteps);
         return config;
     }
 
     @Override public ISpoofaxLanguageSpecConfigBuilder reset() {
         super.reset();
         sdfVersion = null;
+        sdf2tableVersion = null;
         sdfExternalDef = null;
         sdfArgs = null;
         strFormat = null;
@@ -67,6 +69,7 @@ public class SpoofaxLanguageSpecConfigBuilder extends LanguageSpecConfigBuilder
         super.copyFrom(config);
         if(!(config instanceof IConfig)) {
             withSdfVersion(config.sdfVersion());
+            withSdf2tableVersion(config.sdf2tableVersion());
             withSdfExternalDef(config.sdfExternalDef());
             withSdfArgs(config.sdfArgs());
             withStrFormat(config.strFormat());
@@ -174,6 +177,11 @@ public class SpoofaxLanguageSpecConfigBuilder extends LanguageSpecConfigBuilder
 
     @Override public ISpoofaxLanguageSpecConfigBuilder withSdfVersion(SdfVersion sdfVersion) {
         this.sdfVersion = sdfVersion;
+        return null;
+    }
+    
+    @Override public ISpoofaxLanguageSpecConfigBuilder withSdf2tableVersion(Sdf2tableVersion sdf2tableVersion) {
+        this.sdf2tableVersion = sdf2tableVersion;
         return null;
     }
 

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/build/Sdf2TableNew.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/build/Sdf2TableNew.java
@@ -1,0 +1,82 @@
+package org.metaborg.spoofax.meta.core.pluto.build;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.metaborg.sdf2table.parsetable.ParseTable;
+import org.metaborg.spoofax.meta.core.pluto.SpoofaxBuilder;
+import org.metaborg.spoofax.meta.core.pluto.SpoofaxBuilderFactory;
+import org.metaborg.spoofax.meta.core.pluto.SpoofaxBuilderFactoryFactory;
+import org.metaborg.spoofax.meta.core.pluto.SpoofaxContext;
+import org.metaborg.spoofax.meta.core.pluto.SpoofaxInput;
+
+import build.pluto.BuildUnit.State;
+import build.pluto.builder.BuildRequest;
+import build.pluto.dependency.Origin;
+import build.pluto.output.OutputPersisted;
+
+public class Sdf2TableNew extends SpoofaxBuilder<Sdf2TableNew.Input, OutputPersisted<File>> {
+    public static class Input extends SpoofaxInput {
+        private static final long serialVersionUID = -2379365089609792204L;
+
+        public final File inputFile;
+        public final File outputFile;
+        public final String path;
+
+
+        public Input(SpoofaxContext context, File inputFile, File outputFile, String path) {
+            super(context);
+            this.inputFile = inputFile;
+            this.outputFile = outputFile;
+            this.path = path;
+        }
+    }
+
+
+    public static SpoofaxBuilderFactory<Input, OutputPersisted<File>, Sdf2TableNew> factory =
+        SpoofaxBuilderFactoryFactory.of(Sdf2TableNew.class, Input.class);
+
+
+    public Sdf2TableNew(Input input) {
+        super(input);
+    }
+
+
+    public static
+        BuildRequest<Input, OutputPersisted<File>, Sdf2TableNew, SpoofaxBuilderFactory<Input, OutputPersisted<File>, Sdf2TableNew>>
+        request(Input input) {
+        return new BuildRequest<>(factory, input);
+    }
+
+    public static Origin origin(Input input) {
+        return Origin.from(request(input));
+    }
+
+
+    @Override protected String description(Input input) {
+        return "Compile grammar to parse table using the Java implementation";
+    }
+
+    @Override public File persistentPath(Input input) {
+        String fileName = input.inputFile.getName();
+        return context.depPath("sdf2table-java." + fileName + ".dep");
+    }
+
+    @Override public OutputPersisted<File> build(Input input) throws IOException {
+        require(input.inputFile);
+        boolean status = true;
+
+        try {
+            ParseTable.fromFile(input.inputFile, input.outputFile, Arrays.asList(input.path));
+        } catch(Exception e) {
+            System.out.println("Failed to generate parse table");
+            e.printStackTrace();
+            status = false;
+        }
+        provide(input.outputFile);
+
+        setState(State.finished(status));
+        return OutputPersisted.of(input.outputFile);
+    }
+}

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/stratego/primitives/CheckSdf2TablePrimitive.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/stratego/primitives/CheckSdf2TablePrimitive.java
@@ -1,0 +1,66 @@
+package org.metaborg.spoofax.meta.core.stratego.primitives;
+
+import org.apache.commons.vfs2.FileObject;
+import org.metaborg.core.config.ConfigException;
+import org.metaborg.core.project.IProject;
+import org.metaborg.core.project.IProjectService;
+import org.metaborg.spoofax.meta.core.project.ISpoofaxLanguageSpec;
+import org.metaborg.spoofax.meta.core.project.ISpoofaxLanguageSpecService;
+import org.metaborg.util.log.ILogger;
+import org.metaborg.util.log.LoggerUtils;
+import org.spoofax.interpreter.core.IContext;
+import org.spoofax.interpreter.core.InterpreterException;
+import org.spoofax.interpreter.library.AbstractPrimitive;
+import org.spoofax.interpreter.stratego.Strategy;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+
+public class CheckSdf2TablePrimitive extends AbstractPrimitive {
+    private static final ILogger logger = LoggerUtils.logger(CheckSdf2TablePrimitive.class);
+
+    @Inject private static Provider<ISpoofaxLanguageSpecService> languageSpecServiceProvider;
+
+    private final IProjectService projectService;
+
+    @Inject public CheckSdf2TablePrimitive(IProjectService projectService) {
+        super("SSL_EXT_check_sdf2_table", 0, 0);
+ 
+        this.projectService = projectService;
+    }
+
+
+    @Override public boolean call(IContext env, Strategy[] svars, IStrategoTerm[] tvars) throws InterpreterException {
+        org.metaborg.core.context.IContext context = (org.metaborg.core.context.IContext) env.contextObject();
+
+        final FileObject location = context.location();
+        final IProject project = projectService.get(location);
+        if(project == null) {
+            return false;
+        }
+
+        if(languageSpecServiceProvider == null) {
+            // Indicates that meta-Spoofax is not available (ISpoofaxLanguageSpecService cannot be injected), but this
+            // should never happen because this primitive is inside meta-Spoofax. Check for null just in case.
+            logger.debug("Language specification service is not available; static injection failed");
+            return false;
+        }
+        final ISpoofaxLanguageSpecService languageSpecService = languageSpecServiceProvider.get();
+        if(!languageSpecService.available(project)) {
+            return false;
+        }
+        final ISpoofaxLanguageSpec languageSpec;
+        try {
+            languageSpec = languageSpecService.get(project);
+        } catch(ConfigException e) {
+            throw new InterpreterException("Unable to get language specification name for " + location, e);
+        }
+        if(languageSpec == null) {
+            return false;
+        }
+
+        env.setCurrent(env.getFactory().makeString(languageSpec.config().sdf2tableVersion().toString()));
+        return true;
+    }
+}


### PR DESCRIPTION
Added a configuration within the `sdf` option in the yaml file to handle the `sdf2table` version (`java` or `c`).
Added a pluto builder to generate the table whenever the `java` version is set.