### PR TITLE
add ProjectService for single file projects that takes parent directory as project location

### DIFF
--- a/org.metaborg.core/src/main/java/org/metaborg/core/project/SingleFileProjectService.java
+++ b/org.metaborg.core/src/main/java/org/metaborg/core/project/SingleFileProjectService.java
@@ -1,0 +1,27 @@
+package org.metaborg.core.project;
+
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+
+/**
+ * Creates a project from a single file with the parent directory as project location (if possible, otherwise just
+ * the file) and no config (== null).
+ * Never returns null for the project.
+ * Doesn't cache projects.
+ */
+public class SingleFileProjectService implements IProjectService {
+
+    @Override
+    public IProject get(FileObject resource) {
+        try {
+            // project location should be a directory (otherwise building gave errors), so take parent dir (if possible)
+            if (resource.isFile()) {
+                return new Project(resource.getParent(), null);
+            } else {
+                return new Project(resource, null);
+            }
+        } catch (FileSystemException e) {
+            return new Project(resource, null);
+        }
+    }
+}


### PR DESCRIPTION
The Green-Marl language has only "single-file compilation units", so a single file project service is handy. Maybe others can use this too?