### PR TITLE
Support multiple name resolution targets

### DIFF
--- a/meta.lib.spoofax/trans/libspoofax/editor/resolution.str
+++ b/meta.lib.spoofax/trans/libspoofax/editor/resolution.str
@@ -1,0 +1,9 @@
+module libspoofax/editor/resolution
+
+signature constructors
+  HyperlinkText : Term -> Term
+
+strategies
+
+  set-resolution-text(|text): t{a*} -> t{a'*}
+  where a'* := [ HyperlinkText(text) | <remove-all(?HyperlinkText(_))> a* ]

--- a/meta.lib.spoofax/trans/libspoofax/editor/resolution.str
+++ b/meta.lib.spoofax/trans/libspoofax/editor/resolution.str
@@ -1,9 +1,27 @@
 module libspoofax/editor/resolution
 
+imports
+
+  libspoofax/term/annotation
+  libspoofax/term/origin
+
 signature constructors
   HyperlinkText : Term -> Term
 
 strategies
 
-  set-resolution-text(|text): t{a*} -> t{a'*}
-  where a'* := [ HyperlinkText(text) | <remove-all(?HyperlinkText(_))> a* ]
+  set-resolution-text(|text) = replace-annotation(?HyperlinkText(_)|HyperlinkText(text))
+
+  sort-resolutions = sort-list(SortL(where((origin-location-offset, origin-location-offset);resolution-gt)))
+
+  resolution-gt: ((file, line, column1, _, _), (file, line, column2, _, _)) -> <id>
+  where <gt> (column1, column2)
+
+  resolution-gt: ((file, line1, _, _, _), (file, line2, _, _, _)) -> <id>
+  where <gt> (line1, line2)
+
+  resolution-gt: ((file1, _, _, _, _), (file2, _, _, _, _)) -> <id>
+  where <not(eq);base-filename;not(eq);string-gt> (file1, file2)
+
+  resolution-gt: ((file1, _, _, _, _), (file2, _, _, _, _)) -> <id>
+  where <not(eq);where(base-filename;eq);string-gt> (file1, file2)

--- a/org.metaborg.core/src/main/java/org/metaborg/core/tracing/Resolution.java
+++ b/org.metaborg.core/src/main/java/org/metaborg/core/tracing/Resolution.java
@@ -43,7 +43,7 @@ public class Resolution {
             ISourceRegion region = location.region();
             int row = region.startRow();
             int col = region.startColumn();
-            return fileName + ":" + row + ":" + col;
+            return fileName + ":" + (row+1) + ":" + (col+1);
         }
     }
 }

--- a/org.metaborg.core/src/main/java/org/metaborg/core/tracing/Resolution.java
+++ b/org.metaborg.core/src/main/java/org/metaborg/core/tracing/Resolution.java
@@ -1,8 +1,5 @@
 package org.metaborg.core.tracing;
 
-import javax.annotation.Nullable;
-
-import org.metaborg.core.source.ISourceLocation;
 import org.metaborg.core.source.ISourceRegion;
 
 /**
@@ -17,33 +14,11 @@ public class Resolution {
     /**
      * Resolution targets. Multiple targets indicate resolution to multiple valid locations.
      */
-    public final Iterable<Resolution.Target> targets;
+    public final Iterable<ResolutionTarget> targets;
 
 
-    public Resolution(ISourceRegion highlight, Iterable<Resolution.Target> targets) {
+    public Resolution(ISourceRegion highlight, Iterable<ResolutionTarget> targets) {
         this.highlight = highlight;
         this.targets = targets;
-    }
-
-    public static class Target {
-        public final @Nullable String hyperlinkName;
-        public final ISourceLocation location;
-
-        public Target(ISourceLocation location) {
-            this(null, location);
-        }
-
-        public Target(String hyperlinkName, ISourceLocation location) {
-            this.hyperlinkName = hyperlinkName == null ? defaultHyperlinkName(location) : hyperlinkName;
-            this.location = location;
-        }
-        
-        private static String defaultHyperlinkName(ISourceLocation location) {
-            String fileName = location.resource().getName().getBaseName();
-            ISourceRegion region = location.region();
-            int row = region.startRow();
-            int col = region.startColumn();
-            return fileName + ":" + (row+1) + ":" + (col+1);
-        }
     }
 }

--- a/org.metaborg.core/src/main/java/org/metaborg/core/tracing/Resolution.java
+++ b/org.metaborg.core/src/main/java/org/metaborg/core/tracing/Resolution.java
@@ -1,5 +1,7 @@
 package org.metaborg.core.tracing;
 
+import javax.annotation.Nullable;
+
 import org.metaborg.core.source.ISourceLocation;
 import org.metaborg.core.source.ISourceRegion;
 
@@ -15,11 +17,25 @@ public class Resolution {
     /**
      * Resolution targets. Multiple targets indicate resolution to multiple valid locations.
      */
-    public final Iterable<ISourceLocation> targets;
+    public final Iterable<Resolution.Target> targets;
 
 
-    public Resolution(ISourceRegion highlight, Iterable<ISourceLocation> targets) {
+    public Resolution(ISourceRegion highlight, Iterable<Resolution.Target> targets) {
         this.highlight = highlight;
         this.targets = targets;
+    }
+
+    public static class Target {
+        public final @Nullable String hyperlinkName;
+        public final ISourceLocation location;
+
+        public Target(ISourceLocation location) {
+            this(null, location);
+        }
+
+        public Target(String hyperlinkName, ISourceLocation location) {
+            this.hyperlinkName = hyperlinkName;
+            this.location = location;
+        }
     }
 }

--- a/org.metaborg.core/src/main/java/org/metaborg/core/tracing/Resolution.java
+++ b/org.metaborg.core/src/main/java/org/metaborg/core/tracing/Resolution.java
@@ -34,8 +34,16 @@ public class Resolution {
         }
 
         public Target(String hyperlinkName, ISourceLocation location) {
-            this.hyperlinkName = hyperlinkName;
+            this.hyperlinkName = hyperlinkName == null ? defaultHyperlinkName(location) : hyperlinkName;
             this.location = location;
+        }
+        
+        private static String defaultHyperlinkName(ISourceLocation location) {
+            String fileName = location.resource().getName().getBaseName();
+            ISourceRegion region = location.region();
+            int row = region.startRow();
+            int col = region.startColumn();
+            return fileName + ":" + row + ":" + col;
         }
     }
 }

--- a/org.metaborg.core/src/main/java/org/metaborg/core/tracing/ResolutionTarget.java
+++ b/org.metaborg.core/src/main/java/org/metaborg/core/tracing/ResolutionTarget.java
@@ -1,0 +1,28 @@
+package org.metaborg.core.tracing;
+
+import javax.annotation.Nullable;
+
+import org.metaborg.core.source.ISourceLocation;
+import org.metaborg.core.source.ISourceRegion;
+
+public class ResolutionTarget {
+    public final String hyperlinkName;
+    public final ISourceLocation location;
+
+    public ResolutionTarget(ISourceLocation location) {
+        this(null, location);
+    }
+
+    public ResolutionTarget(@Nullable String hyperlinkName, ISourceLocation location) {
+        this.hyperlinkName = hyperlinkName == null ? defaultHyperlinkName(location) : hyperlinkName;
+        this.location = location;
+    }
+
+    private static String defaultHyperlinkName(ISourceLocation location) {
+        String fileName = location.resource().getName().getBaseName();
+        ISourceRegion region = location.region();
+        int row = region.startRow();
+        int col = region.startColumn();
+        return fileName + ":" + (row+1) + ":" + (col+1);
+    }
+}

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/SpoofaxModule.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/SpoofaxModule.java
@@ -191,6 +191,7 @@ import mb.nabl2.spoofax.primitives.SG_get_ast_refs;
 import mb.nabl2.spoofax.primitives.SG_get_ast_resolution;
 import mb.nabl2.spoofax.primitives.SG_get_custom_analysis;
 import mb.nabl2.spoofax.primitives.SG_get_decl_property;
+import mb.nabl2.spoofax.primitives.SG_get_decl_resolution;
 import mb.nabl2.spoofax.primitives.SG_get_decl_scope;
 import mb.nabl2.spoofax.primitives.SG_get_direct_edges;
 import mb.nabl2.spoofax.primitives.SG_get_direct_edges_inv;
@@ -412,6 +413,7 @@ public class SpoofaxModule extends MetaborgModule {
         bindPrimitive(spoofaxScopeGraphLibrary, SG_get_ast_resolution.class);
         bindPrimitive(spoofaxScopeGraphLibrary, SG_get_custom_analysis.class);
         bindPrimitive(spoofaxScopeGraphLibrary, SG_get_decl_property.class);
+        bindPrimitive(spoofaxScopeGraphLibrary, SG_get_decl_resolution.class);
         bindPrimitive(spoofaxScopeGraphLibrary, SG_get_decl_scope.class);
         bindPrimitive(spoofaxScopeGraphLibrary, SG_get_direct_edges_inv.class);
         bindPrimitive(spoofaxScopeGraphLibrary, SG_get_direct_edges.class);

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/tracing/ResolverService.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/tracing/ResolverService.java
@@ -19,6 +19,7 @@ import org.metaborg.core.source.ISourceLocation;
 import org.metaborg.core.source.ISourceRegion;
 import org.metaborg.core.source.SourceRegion;
 import org.metaborg.core.tracing.Resolution;
+import org.metaborg.core.tracing.ResolutionTarget;
 import org.metaborg.spoofax.core.stratego.IStrategoRuntimeService;
 import org.metaborg.spoofax.core.terms.ITermFactoryService;
 import org.metaborg.spoofax.core.tracing.TracingCommon.TermWithRegion;
@@ -153,7 +154,7 @@ public class ResolverService implements ISpoofaxResolverService {
         final IStrategoTerm output = tuple.term;
         final ISourceRegion offsetRegion = tuple.region;
 
-        final Collection<Resolution.Target> targets = Lists.newLinkedList();
+        final Collection<ResolutionTarget> targets = Lists.newLinkedList();
         if(output.getTermType() == IStrategoTerm.LIST) {
             for(IStrategoTerm subterm : output) {
                 final String hyperlinkText = getHyperlinkText(subterm);
@@ -162,7 +163,7 @@ public class ResolverService implements ISpoofaxResolverService {
                     logger.debug("Cannot get target location for {}", subterm);
                     continue;
                 }
-                targets.add(new Resolution.Target(hyperlinkText, targetLocation));
+                targets.add(new ResolutionTarget(hyperlinkText, targetLocation));
             }
         } else {
             final String hyperlinkText = getHyperlinkText(output);
@@ -171,7 +172,7 @@ public class ResolverService implements ISpoofaxResolverService {
                 logger.debug("Reference resolution failed, cannot get target location for {}", output);
                 return null;
             }
-            targets.add(new Resolution.Target(hyperlinkText, targetLocation));
+            targets.add(new ResolutionTarget(hyperlinkText, targetLocation));
         }
 
         if(targets.isEmpty()) {


### PR DESCRIPTION
Use a `HyperlinkText/1` term in the annotations of the term that provides the resolution target. That will function as the text to show in the list of resolution targets.  

PR group:
metaborg/spt#23
metaborg/spoofax#38
metaborg/spoofax-eclipse#13
metaborg/nabl#14
metaborg/spoofax-intellij#29

<img width="240" alt="multi-resolution" src="https://user-images.githubusercontent.com/1237863/42413822-ccb3d196-8228-11e8-9372-b318e9d6fc0c.png">
