### PR TITLE
Stratego based imploder

### DIFF
--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/language/dialect/DialectProcessor.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/language/dialect/DialectProcessor.java
@@ -16,6 +16,7 @@ import org.metaborg.core.resource.ResourceChange;
 import org.metaborg.core.resource.ResourceChangeKind;
 import org.metaborg.spoofax.core.SpoofaxConstants;
 import org.metaborg.spoofax.core.resource.SpoofaxIgnoresSelector;
+import org.metaborg.spoofax.core.syntax.ImploderImplementation;
 import org.metaborg.spoofax.core.syntax.SyntaxFacet;
 import org.metaborg.util.log.ILogger;
 import org.metaborg.util.log.LoggerUtils;
@@ -84,7 +85,7 @@ public class DialectProcessor implements IDialectProcessor {
 
             final SyntaxFacet newFacet =
                 new SyntaxFacet(resource, baseFacet.completionParseTable, baseFacet.startSymbols, baseFacet.singleLineCommentPrefixes,
-                    baseFacet.multiLineCommentCharacters, baseFacet.fenceCharacters);
+                    baseFacet.multiLineCommentCharacters, baseFacet.fenceCharacters, ImploderImplementation.stratego);
 
             final ResourceChangeKind changeKind = change.kind;
             try {

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/language/dialect/DialectProcessor.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/language/dialect/DialectProcessor.java
@@ -83,9 +83,10 @@ public class DialectProcessor implements IDialectProcessor {
 
             final String fileName = FilenameUtils.getBaseName(resource.getName().getBaseName());
 
+            // TODO: set imploder setting to ImploderImplementation.stratego by default after it is fixed to preserve origin info
             final SyntaxFacet newFacet =
                 new SyntaxFacet(resource, baseFacet.completionParseTable, baseFacet.startSymbols, baseFacet.singleLineCommentPrefixes,
-                    baseFacet.multiLineCommentCharacters, baseFacet.fenceCharacters, ImploderImplementation.stratego);
+                    baseFacet.multiLineCommentCharacters, baseFacet.fenceCharacters, baseFacet.imploder);
 
             final ResourceChangeKind changeKind = change.kind;
             try {

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/IParserConfig.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/IParserConfig.java
@@ -4,4 +4,6 @@ public interface IParserConfig {
     String getStartSymbol();
 
     IParseTableProvider getParseTableProvider();
+
+    ImploderImplementation getImploderSetting();
 }

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/ImploderImplementation.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/ImploderImplementation.java
@@ -1,0 +1,5 @@
+package org.metaborg.spoofax.core.syntax;
+
+public enum ImploderImplementation {
+    java, stratego
+}

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/IncrementalParserConfig.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/IncrementalParserConfig.java
@@ -5,14 +5,17 @@ import org.metaborg.sdf2table.parsetable.ParseTable;
 public class IncrementalParserConfig implements IParserConfig {
     private final String startSymbol;
     private final IParseTableProvider parseTableProvider;
+    private final ImploderImplementation imploder;
 
     private final ParseTable referenceParseTable;
 
 
-    public IncrementalParserConfig(String startSymbol, IParseTableProvider provider, ParseTable pt) {
+    public IncrementalParserConfig(String startSymbol, IParseTableProvider provider, ParseTable pt,
+        ImploderImplementation imploder) {
         this.startSymbol = startSymbol;
         this.parseTableProvider = provider;
         this.referenceParseTable = pt;
+        this.imploder = imploder;
     }
 
 
@@ -22,6 +25,10 @@ public class IncrementalParserConfig implements IParserConfig {
 
     @Override public IParseTableProvider getParseTableProvider() {
         return this.parseTableProvider;
+    }
+
+    @Override public ImploderImplementation getImploderSetting() {
+        return this.imploder;
     }
 
     public ParseTable getReferenceParseTable() {

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLRParseService.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLRParseService.java
@@ -206,7 +206,7 @@ public class JSGLRParseService implements ISpoofaxParser, ILanguageCache {
                 }
             }
 
-            config = new ParserConfig(Iterables.get(facet.startSymbols, 0), provider);
+            config = new ParserConfig(Iterables.get(facet.startSymbols, 0), provider, facet.imploder);
             parserConfigs.put(lang, config);
 
 
@@ -280,7 +280,7 @@ public class JSGLRParseService implements ISpoofaxParser, ILanguageCache {
                 provider = new JSGLR1FileParseTableProvider(completionParseTable, termFactory);
             }
 
-            config = new ParserConfig(Iterables.get(facet.startSymbols, 0), provider);
+            config = new ParserConfig(Iterables.get(facet.startSymbols, 0), provider, facet.imploder);
             completionParserConfigs.put(lang, config);
 
 

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/ParserConfig.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/ParserConfig.java
@@ -3,11 +3,13 @@ package org.metaborg.spoofax.core.syntax;
 public class ParserConfig implements IParserConfig {
     private final String startSymbol;
     private final IParseTableProvider parseTableProvider;
+    private final ImploderImplementation imploder;
 
 
-    public ParserConfig(String startSymbol, IParseTableProvider provider) {
+    public ParserConfig(String startSymbol, IParseTableProvider provider, ImploderImplementation imploder) {
         this.startSymbol = startSymbol;
         this.parseTableProvider = provider;
+        this.imploder = imploder;
     }
 
 
@@ -17,5 +19,9 @@ public class ParserConfig implements IParserConfig {
 
     @Override public IParseTableProvider getParseTableProvider() {
         return this.parseTableProvider;
+    }
+
+    @Override public ImploderImplementation getImploderSetting() {
+        return this.imploder;
     }
 }

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/SyntaxFacet.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/SyntaxFacet.java
@@ -25,6 +25,7 @@ public class SyntaxFacet implements IFacet {
     public final Iterable<String> singleLineCommentPrefixes;
     public final Iterable<MultiLineCommentCharacters> multiLineCommentCharacters;
     public final Iterable<FenceCharacters> fenceCharacters;
+    public final ImploderImplementation imploder;
 
 
     /**
@@ -37,7 +38,8 @@ public class SyntaxFacet implements IFacet {
      */
     public SyntaxFacet(FileObject parseTable, FileObject completionParseTable, Iterable<String> startSymbols) {
         this(parseTable, completionParseTable, startSymbols, Iterables2.<String>empty(),
-            Iterables2.<MultiLineCommentCharacters>empty(), Iterables2.<FenceCharacters>empty());
+            Iterables2.<MultiLineCommentCharacters>empty(), Iterables2.<FenceCharacters>empty(), 
+            ImploderImplementation.java);
     }
 
     /**
@@ -56,13 +58,14 @@ public class SyntaxFacet implements IFacet {
      */
     public SyntaxFacet(FileObject parseTable, FileObject completionParseTable, Iterable<String> startSymbols,
         Iterable<String> singleLineCommentPrefixes, Iterable<MultiLineCommentCharacters> multiLineCommentCharacters,
-        Iterable<FenceCharacters> fenceCharacters) {
+        Iterable<FenceCharacters> fenceCharacters, ImploderImplementation imploder) {
         this.parseTable = parseTable;
         this.completionParseTable = completionParseTable;
         this.startSymbols = startSymbols;
         this.singleLineCommentPrefixes = singleLineCommentPrefixes;
         this.multiLineCommentCharacters = multiLineCommentCharacters;
         this.fenceCharacters = fenceCharacters;
+        this.imploder = imploder;
     }
 
 

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/SyntaxFacetFromESV.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/SyntaxFacetFromESV.java
@@ -12,6 +12,7 @@ import org.metaborg.core.syntax.FenceCharacters;
 import org.metaborg.core.syntax.MultiLineCommentCharacters;
 import org.metaborg.spoofax.core.esv.ESVReader;
 import org.metaborg.util.iterators.Iterables2;
+import org.spoofax.interpreter.core.Tools;
 import org.spoofax.interpreter.terms.IStrategoAppl;
 
 import com.google.common.collect.Lists;
@@ -30,10 +31,27 @@ public class SyntaxFacetFromESV {
         final Iterable<String> singleLineCommentPrefixes = singleLineCommentPrefixes(esv);
         final Iterable<MultiLineCommentCharacters> multiLineCommentCharacters = multiLineCommentCharacters(esv);
         final Iterable<FenceCharacters> fenceCharacters = fenceCharacters(esv);
+        final ImploderImplementation imploder = imploder(esv);
         final SyntaxFacet syntaxFacet =
             new SyntaxFacet(parseTable, completionParseTable, startSymbols, singleLineCommentPrefixes, multiLineCommentCharacters,
-                fenceCharacters);
+                fenceCharacters, imploder);
         return syntaxFacet;
+    }
+
+
+    private static ImploderImplementation imploder(IStrategoAppl document) {
+        final IStrategoAppl imploder = ESVReader.findTerm(document, "Imploder");
+        if(imploder == null) {
+            return ImploderImplementation.java;
+        }
+        final IStrategoAppl imploderImpl = Tools.applAt(imploder, 0);
+        switch(imploderImpl.getName()) {
+            case "Stratego":
+                return ImploderImplementation.stratego;
+            case "Java":
+                return ImploderImplementation.java;
+        }
+        return ImploderImplementation.java;
     }
 
 


### PR DESCRIPTION
I've added an imploder setting to ESV and to Spoofax Core to be able to select the old Stratego implementation of the imploder which takes an AsFix2 parse tree and yields an AST. This is the imploder used in the Stratego compiler, and the _only_ imploder that currently handles mix-syntax correctly. 

See also: https://github.com/metaborg/esv/pull/4