### PR TITLE
Refactor GenerateSourcesBuilder

### DIFF
--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/build/main/GenerateSourcesBuilder.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/build/main/GenerateSourcesBuilder.java
@@ -192,7 +192,11 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
     }
     
     private void newParseTableGenerationBuild(GenerateSourcesBuilder.Input input, build.pluto.dependency.Origin.Builder sdfBuilder) throws IOException {
-        final Sdf2Table.Input sdf2TableJavaInput = newParseTableGeneration(input);
+        final File srcNormDir = toFile(paths.syntaxNormDir());
+        final File sdfNormFile = FileUtils.getFile(srcNormDir, input.sdfModule + "-norm.aterm");
+        
+        final Sdf2Table.Input sdf2TableJavaInput = newParseTableGeneration(input, sdfNormFile, "sdf.tbl", "table.bin", "ctxgrammar.aterm");
+        
         final Origin sdf2TableJavaOrigin = Sdf2Table.origin(sdf2TableJavaInput);
 
         requireBuild(sdf2TableJavaOrigin);
@@ -208,7 +212,8 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
 
         // Completions
         if(input.sdfCompletionFile != null && input.sdfEnabled) {
-            Sdf2Table.Input sdf2TableJavaInputCompletions = newParseTableGenerationCompletions(input);
+            Sdf2Table.Input sdf2TableJavaInputCompletions = newParseTableGeneration(input, input.sdfCompletionFile, "sdf-completions.tbl", "table-completions.bin", null);
+            
             final Origin sdfCompletionOrigin = Sdf2Table.origin(sdf2TableJavaInputCompletions);
 
             requireBuild(sdfCompletionOrigin);
@@ -217,41 +222,22 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
         }
     }
     
-    private Sdf2Table.Input newParseTableGeneration(GenerateSourcesBuilder.Input input) {
+    private Sdf2Table.Input newParseTableGeneration(GenerateSourcesBuilder.Input input, File sdfNormFile, String tableFilename, String persistedTableFilename, String contextualGrammarFilename) {
         final File targetMetaborgDir = toFile(paths.targetMetaborgDir());
 
         final boolean dynamicGeneration = (input.sdf2tableVersion == Sdf2tableVersion.dynamic
             || input.sdf2tableVersion == Sdf2tableVersion.incremental);
         final boolean dataDependent = (input.jsglrVersion == JSGLRVersion.dataDependent);
         final boolean layoutSensitive = (input.jsglrVersion == JSGLRVersion.layoutSensitive);
-
-        final File srcNormDir = toFile(paths.syntaxNormDir());
-        final File sdfNormFile = FileUtils.getFile(srcNormDir, input.sdfModule + "-norm.aterm");
         
-        final File tableFile = FileUtils.getFile(targetMetaborgDir, "sdf.tbl");
-        final File persistedTableFile = FileUtils.getFile(targetMetaborgDir, "table.bin");
-        final File contextualGrammarFile = FileUtils.getFile(targetMetaborgDir, "ctxgrammar.aterm");
+        final File tableFile = FileUtils.getFile(targetMetaborgDir, tableFilename);
+        final File persistedTableFile = FileUtils.getFile(targetMetaborgDir, persistedTableFilename);
+        final File contextualGrammarFile = contextualGrammarFilename != null ? FileUtils.getFile(targetMetaborgDir, contextualGrammarFilename) : null;
 
         final List<String> paths = srcGenNormalizedSdf3Paths(input);
 
         return new Sdf2Table.Input(context, sdfNormFile, tableFile, persistedTableFile, contextualGrammarFile, paths,
             dynamicGeneration, dataDependent, layoutSensitive);
-    }
-
-    private Sdf2Table.Input newParseTableGenerationCompletions(GenerateSourcesBuilder.Input input) {
-        final File targetMetaborgDir = toFile(paths.targetMetaborgDir());
-
-        final boolean dynamicGeneration = (input.sdf2tableVersion == Sdf2tableVersion.dynamic
-            || input.sdf2tableVersion == Sdf2tableVersion.incremental);
-        final boolean dataDependent = (input.jsglrVersion == JSGLRVersion.dataDependent);
-        final boolean layoutSensitive = (input.jsglrVersion == JSGLRVersion.layoutSensitive);
-        
-        final File tableFile = FileUtils.getFile(targetMetaborgDir, "sdf-completions.tbl");
-        final File persistedTableFile = FileUtils.getFile(targetMetaborgDir, "table-completions.bin");
-        final List<String> paths = srcGenNormalizedSdf3Paths(input);
-
-        return new Sdf2Table.Input(context, input.sdfCompletionFile, tableFile,
-            persistedTableFile, null, paths, dynamicGeneration, dataDependent, layoutSensitive);
     }
 
     private void oldParseTableGenerationBuild(GenerateSourcesBuilder.Input input, build.pluto.dependency.Origin.Builder sdfBuilder) throws IOException {

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/build/main/GenerateSourcesBuilder.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/build/main/GenerateSourcesBuilder.java
@@ -47,6 +47,7 @@ import com.google.common.collect.Lists;
 
 import build.pluto.builder.BuildRequest;
 import build.pluto.dependency.Origin;
+import build.pluto.dependency.Origin.Builder;
 import build.pluto.output.None;
 import build.pluto.output.OutputPersisted;
 import build.pluto.stamp.FileExistsStamper;
@@ -158,7 +159,7 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
 
     @Override public None build(GenerateSourcesBuilder.Input input) throws IOException {
         // SDF
-        build.pluto.dependency.Origin.Builder sdfBuilder = buildSdf(input);
+        Builder sdfBuilder = buildSdf(input);
 
         // SDF meta-module for creating a Stratego concrete syntax extension parse table
         List<Origin> sdfMetaOrigins = buildSdfMeta(input);
@@ -175,8 +176,8 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
         return None.val;
     }
     
-    private build.pluto.dependency.Origin.Builder buildSdf(GenerateSourcesBuilder.Input input) throws IOException {
-        build.pluto.dependency.Origin.Builder sdfBuilder = Origin.Builder();
+    private Builder buildSdf(GenerateSourcesBuilder.Input input) throws IOException {
+        Builder sdfBuilder = Origin.Builder();
         
         if(input.sdfModule != null && input.sdfEnabled) {
             if(input.sdf2tableVersion == Sdf2tableVersion.java || input.sdf2tableVersion == Sdf2tableVersion.dynamic
@@ -190,7 +191,7 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
         return sdfBuilder;
     }
     
-    private void newParseTableGenerationBuild(GenerateSourcesBuilder.Input input, build.pluto.dependency.Origin.Builder sdfBuilder) throws IOException {
+    private void newParseTableGenerationBuild(GenerateSourcesBuilder.Input input, Builder sdfBuilder) throws IOException {
         // Standard parser generation
         final File srcNormDir = toFile(paths.syntaxNormDir());
         final File sdfNormFile = FileUtils.getFile(srcNormDir, input.sdfModule + "-norm.aterm");
@@ -239,7 +240,7 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
             dynamicGeneration, dataDependent, layoutSensitive);
     }
 
-    private void oldParseTableGenerationBuild(GenerateSourcesBuilder.Input input, build.pluto.dependency.Origin.Builder sdfBuilder) throws IOException {
+    private void oldParseTableGenerationBuild(GenerateSourcesBuilder.Input input, Builder sdfBuilder) throws IOException {
         File srcGenSyntaxDir = toFile(paths.syntaxSrcGenDir());
         
         // Packing normalized .sdf files in a single .def file
@@ -319,7 +320,7 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
 
     }
     
-    private Origin oldParseTableGenerationSignatures(GenerateSourcesBuilder.Input input, build.pluto.dependency.Origin.Builder sdfBuilder, PackSdfBuild packSdfBuild, File srcGenSyntaxDir, String sdfModule, File sdfExternalDef) {
+    private Origin oldParseTableGenerationSignatures(GenerateSourcesBuilder.Input input, Builder sdfBuilder, PackSdfBuild packSdfBuild, File srcGenSyntaxDir, String sdfModule, File sdfExternalDef) {
         final File srcGenSigDir = toFile(paths.syntaxSrcGenSignatureDir());
         final File rtgFile = FileUtils.getFile(srcGenSigDir, sdfModule + ".rtg");
         final Origin rtgOrigin = Sdf2Rtg.origin(new Sdf2Rtg.Input(context, packSdfBuild.file, rtgFile, sdfModule, packSdfBuild.origin));
@@ -331,7 +332,7 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
         return sigOrigin;
     }
     
-    private Origin oldParseTableGenerationParenthesize(GenerateSourcesBuilder.Input input, build.pluto.dependency.Origin.Builder sdfBuilder, PackSdfBuild packSdfBuild, String sdfModule) {
+    private Origin oldParseTableGenerationParenthesize(GenerateSourcesBuilder.Input input, Builder sdfBuilder, PackSdfBuild packSdfBuild, String sdfModule) {
         final File srcGenPpDir = toFile(paths.syntaxSrcGenPpDir());
         final File parenthesizeFile = FileUtils.getFile(srcGenPpDir, sdfModule + "-parenthesize.str");
         final String parenthesizeModule = "pp/" + sdfModule + "-parenthesize";

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/build/main/GenerateSourcesBuilder.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/build/main/GenerateSourcesBuilder.java
@@ -205,7 +205,7 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
         final File parenthesizerFile = FileUtils.getFile(srcGenPpDir, input.sdfModule + "-parenthesize.str");
         
         final Origin javaParenthesizeOrigin = Sdf2Parenthesize.origin(
-            new Sdf2Parenthesize.Input(context, sdf2TableJavaInput.outputFile, parenthesizerFile, input.sdfModule));
+            new Sdf2Parenthesize.Input(context, sdf2TableJavaInput.outputNormGrammarFile, parenthesizerFile, input.sdfModule));
         
         sdfBuilder.add(javaParenthesizeOrigin);
 

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/build/main/GenerateSourcesBuilder.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/build/main/GenerateSourcesBuilder.java
@@ -299,7 +299,7 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
         return new PackSdfBuild(packSdfFile, packSdfOrigin);
     }
     
-    private class PackSdfBuild {
+    private static class PackSdfBuild {
         
         final @Nullable File file;
         final @Nullable Origin origin;
@@ -340,7 +340,7 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
         return new MakePermissiveBuild(permissiveDefFile, permissiveDefOrigin); 
     }
     
-    private class MakePermissiveBuild {
+    private static class MakePermissiveBuild {
         
         final @Nullable File file;
         final @Nullable Origin origin;

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/build/main/GenerateSourcesBuilder.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/build/main/GenerateSourcesBuilder.java
@@ -232,133 +232,142 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
 
         return null;
     }
+    
+    private void newParseTableGenerationBuild(GenerateSourcesBuilder.Input input, build.pluto.dependency.Origin.Builder sdfBuilder) throws IOException {
+        final File srcGenPpDir = toFile(paths.syntaxSrcGenPpDir());
+        
+        final @Nullable Origin javaParenthesizeOrigin;
+        final @Nullable Origin sdfCompletionOrigin;
+        
+        final Sdf2Table.Input sdf2TableJavaInput = newParseTableGeneration(input);
+        final Origin sdf2TableJavaOrigin = Sdf2Table.origin(sdf2TableJavaInput);
 
-    @Override public None build(GenerateSourcesBuilder.Input input) throws IOException {
-        final File srcGenSigDir = toFile(paths.syntaxSrcGenSignatureDir());
+        requireBuild(sdf2TableJavaOrigin);
+
+        // New parenthesizer
+        final File parenthesizerFile = FileUtils.getFile(srcGenPpDir, input.sdfModule + "-parenthesize.str");
+        javaParenthesizeOrigin = Sdf2Parenthesize.origin(
+            new Sdf2Parenthesize.Input(context, sdf2TableJavaInput.outputFile, parenthesizerFile, input.sdfModule));
+
+        // Completions
+        if(input.sdfCompletionFile != null && input.sdfEnabled) {
+            Sdf2Table.Input sdf2TableJavaInputCompletions = newParseTableGenerationCompletions(input);
+            sdfCompletionOrigin = Sdf2Table.origin(sdf2TableJavaInputCompletions);
+
+            requireBuild(sdfCompletionOrigin);
+        } else {
+            sdfCompletionOrigin = null;
+        }
+        
+        sdfBuilder = sdfBuilder
+            .add(sdfCompletionOrigin)
+            .add(javaParenthesizeOrigin);
+    }
+
+    private void oldParseTableGenerationBuild(GenerateSourcesBuilder.Input input, build.pluto.dependency.Origin.Builder sdfBuilder) throws IOException {
+        final String sdfModule = input.sdfModule;
+        final File sdfFile = input.sdfFile;
+
         final File srcGenSyntaxDir = toFile(paths.syntaxSrcGenDir());
-        final File srcGenSyntaxCompletionDir = toFile(paths.syntaxCompletionSrcGenDir());
+        final File srcGenSigDir = toFile(paths.syntaxSrcGenSignatureDir());
         final File srcGenPpDir = toFile(paths.syntaxSrcGenPpDir());
 
         final File targetMetaborgDir = toFile(paths.targetMetaborgDir());
 
+        // Get the SDF def file, either from existing external def, or by running pack SDF on the grammar
+        // specification.
+        final @Nullable File packSdfFile;
+        final @Nullable Origin packSdfOrigin;
+        final @Nullable Origin parenthesizeOrigin;
+        final @Nullable Origin sigOrigin;
+        final @Nullable Origin sdfCompletionOrigin;
+        
+        if(input.sdfExternalDef != null) {
+            packSdfFile = input.sdfExternalDef;
+            packSdfOrigin = null;
+        } else if(sdfFile != null) {
+            require(sdfFile, FileExistsStamper.instance);
+            if(!sdfFile.exists()) {
+                throw new IOException("Main SDF file at " + sdfFile + " does not exist");
+            }
+
+            packSdfFile = FileUtils.getFile(srcGenSyntaxDir, sdfModule + ".def");
+            packSdfOrigin = PackSdf.origin(new PackSdf.Input(context, sdfModule, sdfFile, packSdfFile,
+                input.packSdfIncludePaths, input.packSdfArgs, null));
+        } else {
+            packSdfFile = null;
+            packSdfOrigin = null;
+        }
+
+        if(packSdfFile != null) {
+            // Get Stratego signatures file when using an external def, or when using sdf2, from the SDF def
+            // file.
+            if(input.sdfExternalDef != null || input.sdfVersion == SdfVersion.sdf2) {
+                final File rtgFile = FileUtils.getFile(srcGenSigDir, sdfModule + ".rtg");
+                final Origin rtgOrigin =
+                    Sdf2Rtg.origin(new Sdf2Rtg.Input(context, packSdfFile, rtgFile, sdfModule, packSdfOrigin));
+                final File sigFile = FileUtils.getFile(srcGenSigDir, sdfModule + ".str");
+                final String sigModule = "signatures/" + sdfModule;
+                sigOrigin = Rtg2Sig.origin(new Rtg2Sig.Input(context, rtgFile, sigFile, sigModule, rtgOrigin));
+            } else {
+                sigOrigin = null;
+            }
+
+
+            // Get Stratego parenthesizer file, from the SDF def file.
+            final File parenthesizeFile = FileUtils.getFile(srcGenPpDir, sdfModule + "-parenthesize.str");
+            final String parenthesizeModule = "pp/" + sdfModule + "-parenthesize";
+            parenthesizeOrigin = Sdf2ParenthesizeLegacy.origin(new Sdf2ParenthesizeLegacy.Input(context,
+                packSdfFile, parenthesizeFile, sdfModule, parenthesizeModule, packSdfOrigin));
+
+            // Get SDF permissive def file, from the SDF def file.
+            final File permissiveDefFile = FileUtils.getFile(srcGenSyntaxDir, sdfModule + "-permissive.def");
+            final Origin permissiveDefOrigin = MakePermissive.origin(
+                new MakePermissive.Input(context, packSdfFile, permissiveDefFile, sdfModule, packSdfOrigin));
+
+            // Get JSGLR parse table, from the SDF permissive def file.
+            final File tableFile = FileUtils.getFile(targetMetaborgDir, "sdf.tbl");
+            final Origin sdf2TableOrigin = Sdf2TableLegacy.origin(new Sdf2TableLegacy.Input(context,
+                permissiveDefFile, tableFile, sdfModule, permissiveDefOrigin));
+
+            requireBuild(sdf2TableOrigin);
+        } else {
+            parenthesizeOrigin = null;
+            sigOrigin = null;
+        }
+        
+        // Completions
+        if(input.sdfCompletionFile != null && input.sdfEnabled) {
+            sdfCompletionOrigin = oldParseTableGenerationCompletions(input);
+            
+            requireBuild(sdfCompletionOrigin);
+        } else {
+            sdfCompletionOrigin = null;
+        }
+        
+        sdfBuilder = sdfBuilder
+            .add(parenthesizeOrigin)
+            .add(sigOrigin)
+            .add(sdfCompletionOrigin);
+    }
+    
+    @Override public None build(GenerateSourcesBuilder.Input input) throws IOException {
         // SDF
         build.pluto.dependency.Origin.Builder sdfBuilder = Origin.Builder();
         
         if(input.sdfModule != null && input.sdfEnabled) {
-            final String sdfModule = input.sdfModule;
-            final File sdfFile = input.sdfFile;
-
             // new parse table generator
             if(input.sdf2tableVersion == Sdf2tableVersion.java || input.sdf2tableVersion == Sdf2tableVersion.dynamic
                 || input.sdf2tableVersion == Sdf2tableVersion.incremental) {
-                final @Nullable Origin javaParenthesizeOrigin;
-                final @Nullable Origin sdfCompletionOrigin;
-                
-                final Sdf2Table.Input sdf2TableJavaInput = newParseTableGeneration(input);
-                final Origin sdf2TableJavaOrigin = Sdf2Table.origin(sdf2TableJavaInput);
-
-                requireBuild(sdf2TableJavaOrigin);
-
-                // New parenthesizer
-                final File parenthesizerFile = FileUtils.getFile(srcGenPpDir, sdfModule + "-parenthesize.str");
-                javaParenthesizeOrigin = Sdf2Parenthesize.origin(
-                    new Sdf2Parenthesize.Input(context, sdf2TableJavaInput.outputFile, parenthesizerFile, sdfModule));
-
-                // Completions
-                if(input.sdfCompletionFile != null && input.sdfEnabled) {
-                    Sdf2Table.Input sdf2TableJavaInputCompletions = newParseTableGenerationCompletions(input);
-                    sdfCompletionOrigin = Sdf2Table.origin(sdf2TableJavaInputCompletions);
-    
-                    requireBuild(sdfCompletionOrigin);
-                } else {
-                    sdfCompletionOrigin = null;
-                }
-                
-                sdfBuilder = sdfBuilder
-                    .add(sdfCompletionOrigin)
-                    .add(javaParenthesizeOrigin);
+                newParseTableGenerationBuild(input, sdfBuilder);
             } else {
-
-                // Get the SDF def file, either from existing external def, or by running pack SDF on the grammar
-                // specification.
-                final @Nullable File packSdfFile;
-                final @Nullable Origin packSdfOrigin;
-                final @Nullable Origin parenthesizeOrigin;
-                final @Nullable Origin sigOrigin;
-                final @Nullable Origin sdfCompletionOrigin;
-                
-                if(input.sdfExternalDef != null) {
-                    packSdfFile = input.sdfExternalDef;
-                    packSdfOrigin = null;
-                } else if(sdfFile != null) {
-                    require(sdfFile, FileExistsStamper.instance);
-                    if(!sdfFile.exists()) {
-                        throw new IOException("Main SDF file at " + sdfFile + " does not exist");
-                    }
-
-                    packSdfFile = FileUtils.getFile(srcGenSyntaxDir, sdfModule + ".def");
-                    packSdfOrigin = PackSdf.origin(new PackSdf.Input(context, sdfModule, sdfFile, packSdfFile,
-                        input.packSdfIncludePaths, input.packSdfArgs, null));
-                } else {
-                    packSdfFile = null;
-                    packSdfOrigin = null;
-                }
-
-                if(packSdfFile != null) {
-                    // Get Stratego signatures file when using an external def, or when using sdf2, from the SDF def
-                    // file.
-                    if(input.sdfExternalDef != null || input.sdfVersion == SdfVersion.sdf2) {
-                        final File rtgFile = FileUtils.getFile(srcGenSigDir, sdfModule + ".rtg");
-                        final Origin rtgOrigin =
-                            Sdf2Rtg.origin(new Sdf2Rtg.Input(context, packSdfFile, rtgFile, sdfModule, packSdfOrigin));
-                        final File sigFile = FileUtils.getFile(srcGenSigDir, sdfModule + ".str");
-                        final String sigModule = "signatures/" + sdfModule;
-                        sigOrigin = Rtg2Sig.origin(new Rtg2Sig.Input(context, rtgFile, sigFile, sigModule, rtgOrigin));
-                    } else {
-                        sigOrigin = null;
-                    }
-
-
-                    // Get Stratego parenthesizer file, from the SDF def file.
-                    final File parenthesizeFile = FileUtils.getFile(srcGenPpDir, sdfModule + "-parenthesize.str");
-                    final String parenthesizeModule = "pp/" + sdfModule + "-parenthesize";
-                    parenthesizeOrigin = Sdf2ParenthesizeLegacy.origin(new Sdf2ParenthesizeLegacy.Input(context,
-                        packSdfFile, parenthesizeFile, sdfModule, parenthesizeModule, packSdfOrigin));
-
-                    // Get SDF permissive def file, from the SDF def file.
-                    final File permissiveDefFile = FileUtils.getFile(srcGenSyntaxDir, sdfModule + "-permissive.def");
-                    final Origin permissiveDefOrigin = MakePermissive.origin(
-                        new MakePermissive.Input(context, packSdfFile, permissiveDefFile, sdfModule, packSdfOrigin));
-
-                    // Get JSGLR parse table, from the SDF permissive def file.
-                    final File tableFile = FileUtils.getFile(targetMetaborgDir, "sdf.tbl");
-                    final Origin sdf2TableOrigin = Sdf2TableLegacy.origin(new Sdf2TableLegacy.Input(context,
-                        permissiveDefFile, tableFile, sdfModule, permissiveDefOrigin));
-
-                    requireBuild(sdf2TableOrigin);
-                } else {
-                    parenthesizeOrigin = null;
-                    sigOrigin = null;
-                }
-                
-                // Completions
-                if(input.sdfCompletionFile != null && input.sdfEnabled) {
-                    sdfCompletionOrigin = oldParseTableGenerationCompletions(input);
-                    
-                    requireBuild(sdfCompletionOrigin);
-                } else {
-                    sdfCompletionOrigin = null;
-                }
-                
-                sdfBuilder = sdfBuilder
-                    .add(parenthesizeOrigin)
-                    .add(sigOrigin)
-                    .add(sdfCompletionOrigin);
+                oldParseTableGenerationBuild(input, sdfBuilder);
             }
         }
 
-
         // SDF meta-module for creating a Stratego concrete syntax extension parse table
+        final File srcGenSyntaxDir = toFile(paths.syntaxSrcGenDir());
+        
         final List<Origin> sdfMetaOrigins = Lists.newArrayList();
 
         for(int i = 0; i < input.sdfMetaFiles.size(); i++) {
@@ -402,6 +411,8 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
         final Origin sdfOrigin = sdfBuilder.get();
 
         // Stratego
+        final File targetMetaborgDir = toFile(paths.targetMetaborgDir());
+        
         final File strFile = input.strFile;
         if(strFile != null) {
             require(strFile, FileExistsStamper.instance);

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/build/main/GenerateSourcesBuilder.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/build/main/GenerateSourcesBuilder.java
@@ -351,8 +351,7 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
             .add(sdfCompletionOrigin);
     }
     
-    @Override public None build(GenerateSourcesBuilder.Input input) throws IOException {
-        // SDF
+    private build.pluto.dependency.Origin.Builder buildSdf(GenerateSourcesBuilder.Input input) throws IOException {
         build.pluto.dependency.Origin.Builder sdfBuilder = Origin.Builder();
         
         if(input.sdfModule != null && input.sdfEnabled) {
@@ -364,8 +363,11 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
                 oldParseTableGenerationBuild(input, sdfBuilder);
             }
         }
-
-        // SDF meta-module for creating a Stratego concrete syntax extension parse table
+        
+        return sdfBuilder;
+    }
+    
+    private List<Origin> buildSdfMeta(GenerateSourcesBuilder.Input input) throws IOException {
         final File srcGenSyntaxDir = toFile(paths.syntaxSrcGenDir());
         
         final List<Origin> sdfMetaOrigins = Lists.newArrayList();
@@ -404,13 +406,10 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
             }
         }
         
-        for(Origin sdfMetaOrigin :  sdfMetaOrigins) {
-            sdfBuilder = sdfBuilder.add(sdfMetaOrigin);
-        }
-        
-        final Origin sdfOrigin = sdfBuilder.get();
-
-        // Stratego
+        return sdfMetaOrigins;
+    }
+    
+    private void buildStratego(GenerateSourcesBuilder.Input input, Origin sdfOrigin) throws IOException {
         final File targetMetaborgDir = toFile(paths.targetMetaborgDir());
         
         final File strFile = input.strFile;
@@ -475,6 +474,23 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
             final Origin typesmartOrigin = Typesmart.origin(typesmartInput);
             requireBuild(typesmartOrigin);
         }
+    }
+    
+    @Override public None build(GenerateSourcesBuilder.Input input) throws IOException {
+        // SDF
+        build.pluto.dependency.Origin.Builder sdfBuilder = buildSdf(input);
+
+        // SDF meta-module for creating a Stratego concrete syntax extension parse table
+        List<Origin> sdfMetaOrigins = buildSdfMeta(input);
+        
+        for(Origin sdfMetaOrigin :  sdfMetaOrigins) {
+            sdfBuilder = sdfBuilder.add(sdfMetaOrigin);
+        }
+        
+        final Origin sdfOrigin = sdfBuilder.get();
+
+        // Stratego
+        buildStratego(input, sdfOrigin);
 
         return None.val;
     }

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/build/main/GenerateSourcesBuilder.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/build/main/GenerateSourcesBuilder.java
@@ -184,41 +184,7 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
                 final File contextualGrammarFile = FileUtils.getFile(targetMetaborgDir, "ctxgrammar.aterm");
                 final File persistedTableFile = FileUtils.getFile(targetMetaborgDir, "table.bin");
                 final File sdfNormFile = FileUtils.getFile(srcNormDir, sdfModule + "-norm.aterm");
-                final List<String> paths = Lists.newLinkedList();
-                paths.add(srcGenSyntaxDir.getAbsolutePath());
-
-                for(LanguageIdentifier langId : input.sourceDeps) {
-                    ILanguageImpl lang = context.languageService().getImpl(langId);
-                    for(final ILanguageComponent component : lang.components()) {
-                        ILanguageComponentConfig config = component.config();
-                        Collection<IExportConfig> exports = config.exports();
-                        for(IExportConfig exportConfig : exports) {
-                            exportConfig.accept(new IExportVisitor() {
-                                @Override public void visit(LangDirExport export) {
-                                    if(export.language.equals(SpoofaxConstants.LANG_ATERM_NAME)) {
-                                        try {
-                                            paths
-                                                .add(toFileReplicate(component.location().resolveFile(export.directory))
-                                                    .getAbsolutePath());
-                                        } catch(FileSystemException e) {
-                                            System.out.println("Failed to locate path");
-                                            e.printStackTrace();
-                                        }
-                                    }
-                                }
-
-                                @Override public void visit(LangFileExport export) {
-                                    // Ignore file exports
-                                }
-
-                                @Override public void visit(ResourceExport export) {
-                                    // Ignore resource exports
-
-                                }
-                            });
-                        }
-                    }
-                }
+                final List<String> paths = srcGenNormalizedSdf3Paths(input);
 
                 final Origin sdf2TableJavaOrigin =
                     Sdf2Table.origin(new Sdf2Table.Input(context, sdfNormFile, tableFile, persistedTableFile,
@@ -318,41 +284,7 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
                 final boolean dataDependent = (input.jsglrVersion == JSGLRVersion.dataDependent);
                 final boolean layoutSensitive = (input.jsglrVersion == JSGLRVersion.layoutSensitive);
                 final File persistedTableFile = FileUtils.getFile(targetMetaborgDir, "table-completions.bin");
-                final List<String> paths = Lists.newLinkedList();
-                paths.add(srcGenSyntaxDir.getAbsolutePath());
-
-                for(LanguageIdentifier langId : input.sourceDeps) {
-                    ILanguageImpl lang = context.languageService().getImpl(langId);
-                    for(final ILanguageComponent component : lang.components()) {
-                        ILanguageComponentConfig config = component.config();
-                        Collection<IExportConfig> exports = config.exports();
-                        for(IExportConfig exportConfig : exports) {
-                            exportConfig.accept(new IExportVisitor() {
-                                @Override public void visit(LangDirExport export) {
-                                    if(export.language.equals(SpoofaxConstants.LANG_ATERM_NAME)) {
-                                        try {
-                                            paths
-                                                .add(toFileReplicate(component.location().resolveFile(export.directory))
-                                                    .getAbsolutePath());
-                                        } catch(FileSystemException e) {
-                                            System.out.println("Failed to locate path");
-                                            e.printStackTrace();
-                                        }
-                                    }
-                                }
-
-                                @Override public void visit(LangFileExport export) {
-                                    // Ignore file exports
-                                }
-
-                                @Override public void visit(ResourceExport export) {
-                                    // Ignore resource exports
-
-                                }
-                            });
-                        }
-                    }
-                }
+                final List<String> paths = srcGenNormalizedSdf3Paths(input);
 
                 final File tableFile = FileUtils.getFile(targetMetaborgDir, "sdf-completions.tbl");
                 sdfCompletionOrigin = Sdf2Table.origin(new Sdf2Table.Input(context, sdfCompletionsFile, tableFile,
@@ -539,5 +471,47 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
         }
 
         return None.val;
+    }
+    
+    private List<String> srcGenNormalizedSdf3Paths(GenerateSourcesBuilder.Input input) {
+        File srcGenSyntaxDir = toFile(paths.syntaxSrcGenDir());
+        
+        final List<String> paths = Lists.newLinkedList();
+        
+        paths.add(srcGenSyntaxDir.getAbsolutePath());
+
+        for(LanguageIdentifier langId : input.sourceDeps) {
+            ILanguageImpl lang = context.languageService().getImpl(langId);
+            for(final ILanguageComponent component : lang.components()) {
+                ILanguageComponentConfig config = component.config();
+                Collection<IExportConfig> exports = config.exports();
+                for(IExportConfig exportConfig : exports) {
+                    exportConfig.accept(new IExportVisitor() {
+                        @Override public void visit(LangDirExport export) {
+                            if(export.language.equals(SpoofaxConstants.LANG_ATERM_NAME)) {
+                                try {
+                                    paths
+                                        .add(toFileReplicate(component.location().resolveFile(export.directory))
+                                            .getAbsolutePath());
+                                } catch(FileSystemException e) {
+                                    System.out.println("Failed to locate path");
+                                    e.printStackTrace();
+                                }
+                            }
+                        }
+
+                        @Override public void visit(LangFileExport export) {
+                            // Ignore file exports
+                        }
+
+                        @Override public void visit(ResourceExport export) {
+                            // Ignore resource exports
+                        }
+                    });
+                }
+            }
+        }
+        
+        return paths;
     }
 }

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/build/main/GenerateSourcesBuilder.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/build/main/GenerateSourcesBuilder.java
@@ -259,7 +259,7 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
             sdfCompletionOrigin = null;
         }
         
-        sdfBuilder = sdfBuilder
+        sdfBuilder
             .add(sdfCompletionOrigin)
             .add(javaParenthesizeOrigin);
     }
@@ -345,7 +345,7 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
             sdfCompletionOrigin = null;
         }
         
-        sdfBuilder = sdfBuilder
+        sdfBuilder
             .add(parenthesizeOrigin)
             .add(sigOrigin)
             .add(sdfCompletionOrigin);

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/build/main/GenerateSourcesBuilder.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/build/main/GenerateSourcesBuilder.java
@@ -245,17 +245,15 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
         build.pluto.dependency.Origin.Builder sdfBuilder = Origin.Builder();
         
         if(input.sdfModule != null && input.sdfEnabled) {
-            final @Nullable Origin parenthesizeOrigin;
-            final @Nullable Origin javaParenthesizeOrigin;
-            final @Nullable Origin sigOrigin;
-            final @Nullable Origin sdfCompletionOrigin;
-            
             final String sdfModule = input.sdfModule;
             final File sdfFile = input.sdfFile;
 
             // new parse table generator
             if(input.sdf2tableVersion == Sdf2tableVersion.java || input.sdf2tableVersion == Sdf2tableVersion.dynamic
                 || input.sdf2tableVersion == Sdf2tableVersion.incremental) {
+                final @Nullable Origin javaParenthesizeOrigin;
+                final @Nullable Origin sdfCompletionOrigin;
+                
                 final Sdf2Table.Input sdf2TableJavaInput = newParseTableGeneration(input);
                 final Origin sdf2TableJavaOrigin = Sdf2Table.origin(sdf2TableJavaInput);
 
@@ -265,9 +263,6 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
                 final File parenthesizerFile = FileUtils.getFile(srcGenPpDir, sdfModule + "-parenthesize.str");
                 javaParenthesizeOrigin = Sdf2Parenthesize.origin(
                     new Sdf2Parenthesize.Input(context, sdf2TableJavaInput.outputFile, parenthesizerFile, sdfModule));
-
-                parenthesizeOrigin = null;
-                sigOrigin = null;
 
                 // Completions
                 if(input.sdfCompletionFile != null && input.sdfEnabled) {
@@ -279,7 +274,7 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
                     sdfCompletionOrigin = null;
                 }
                 
-                sdfBuilder = sdfBuilder.add(sigOrigin)
+                sdfBuilder = sdfBuilder
                     .add(sdfCompletionOrigin)
                     .add(javaParenthesizeOrigin);
             } else {
@@ -288,6 +283,10 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
                 // specification.
                 final @Nullable File packSdfFile;
                 final @Nullable Origin packSdfOrigin;
+                final @Nullable Origin parenthesizeOrigin;
+                final @Nullable Origin sigOrigin;
+                final @Nullable Origin sdfCompletionOrigin;
+                
                 if(input.sdfExternalDef != null) {
                     packSdfFile = input.sdfExternalDef;
                     packSdfOrigin = null;
@@ -337,11 +336,7 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
                         permissiveDefFile, tableFile, sdfModule, permissiveDefOrigin));
 
                     requireBuild(sdf2TableOrigin);
-                    javaParenthesizeOrigin = null;
-
-
                 } else {
-                    javaParenthesizeOrigin = null;
                     parenthesizeOrigin = null;
                     sigOrigin = null;
                 }


### PR DESCRIPTION
An attempt to improve understandability and maintainability of `org.metaborg.spoofax.meta.core.pluto.build.main.GenerateSourcesBuilder`, mostly by factoring out build steps and redundant code to separate methods. 

A secondary goal is preparing the migration to PIE.

Already reviewed by @udesou.