### PR TITLE
Make incremental parser available in Spoofax Core

### DIFF
--- a/org.metaborg.core/src/main/java/org/metaborg/core/config/JSGLRVersion.java
+++ b/org.metaborg.core/src/main/java/org/metaborg/core/config/JSGLRVersion.java
@@ -1,5 +1,5 @@
 package org.metaborg.core.config;
 
 public enum JSGLRVersion {
-	v1, v2, dataDependent, layoutSensitive
+	v1, v2, dataDependent, incremental, layoutSensitive
 }

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLR1I.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLR1I.java
@@ -14,15 +14,7 @@ import org.metaborg.spoofax.core.unit.ParseContrib;
 import org.metaborg.util.time.Timer;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermFactory;
-import org.spoofax.jsglr.client.Asfix2TreeBuilder;
-import org.spoofax.jsglr.client.Disambiguator;
-import org.spoofax.jsglr.client.FilterException;
-import org.spoofax.jsglr.client.InvalidParseTableException;
-import org.spoofax.jsglr.client.NullTreeBuilder;
-import org.spoofax.jsglr.client.ParseException;
-import org.spoofax.jsglr.client.ParseTable;
-import org.spoofax.jsglr.client.SGLRParseResult;
-import org.spoofax.jsglr.client.StartSymbolException;
+import org.spoofax.jsglr.client.*;
 import org.spoofax.jsglr.client.imploder.NullTokenizer;
 import org.spoofax.jsglr.client.imploder.TermTreeFactory;
 import org.spoofax.jsglr.client.imploder.TreeBuilder;
@@ -35,17 +27,20 @@ import org.strategoxt.lang.Context;
 import org.strategoxt.stratego_sglr.implode_asfix_0_0;
 
 public class JSGLR1I extends JSGLRI<ParseTable> {
+    private final ParseTable parseTable;
     private final SGLR parser;
 
-    public JSGLR1I(IParserConfig config, ITermFactory termFactory, ILanguageImpl language, ILanguageImpl dialect,
-        @Nullable FileObject resource, String input) throws IOException, InvalidParseTableException {
-        super(config, termFactory, language, dialect, resource, input);
+    public JSGLR1I(IParserConfig config, ITermFactory termFactory, ILanguageImpl language, ILanguageImpl dialect)
+        throws IOException {
+        super(config, termFactory, language, dialect);
 
         final TermTreeFactory factory = new TermTreeFactory(new ParentTermFactory(termFactory));
-        this.parser = new SGLR(new TreeBuilder(factory), getParseTable(config.getParseTableProvider()));
+        this.parseTable = getParseTable(config.getParseTableProvider());
+        this.parser = new SGLR(new TreeBuilder(factory), parseTable);
     }
 
-    public ParseContrib parse(@Nullable JSGLRParserConfiguration parserConfig) throws IOException {
+    @Override public ParseContrib parse(@Nullable JSGLRParserConfiguration parserConfig, @Nullable FileObject resource,
+        String input) {
         if(parserConfig == null) {
             parserConfig = new JSGLRParserConfiguration();
         }
@@ -53,7 +48,7 @@ public class JSGLR1I extends JSGLRI<ParseTable> {
         final String fileName = resource != null ? resource.getName().getURI() : null;
 
         final JSGLRParseErrorHandler errorHandler =
-            new JSGLRParseErrorHandler(this, resource, getParseTable(config.getParseTableProvider()).hasRecovers());
+            new JSGLRParseErrorHandler(this, resource, parseTable.hasRecovers());
 
         final Timer timer = new Timer(true);
         SGLRParseResult result;
@@ -117,7 +112,8 @@ public class JSGLR1I extends JSGLRI<ParseTable> {
             disambiguator.setHeuristicFilters(false);
         }
 
-        SGLRParseResult parseResult = parseAndRecover(text, filename, disambiguator, getOrDefaultStartSymbol(parserConfig));
+        SGLRParseResult parseResult =
+            parseAndRecover(text, filename, disambiguator, getOrDefaultStartSymbol(parserConfig));
         if(config.getImploderSetting() == ImploderImplementation.stratego) {
             final implode_asfix_0_0 imploder = implode_asfix_0_0.instance;
             final Context strategoContext = new Context(this.termFactory);
@@ -139,7 +135,7 @@ public class JSGLR1I extends JSGLRI<ParseTable> {
                 disambiguator.setFilterPriorities(false);
                 disambiguator.setFilterAssociativity(false);
                 try {
-                    return  parser.parse(text, filename, startSymbol);
+                    return parser.parse(text, filename, startSymbol);
                 } finally {
                     disambiguator.setFilterPriorities(true);
                 }
@@ -157,7 +153,7 @@ public class JSGLR1I extends JSGLRI<ParseTable> {
         }
     }
 
-    public Set<BadTokenException> getCollectedErrors() {
+    @Override public Set<BadTokenException> getCollectedErrors() {
         return parser.getCollectedErrors();
     }
 }

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLR2I.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLR2I.java
@@ -24,8 +24,8 @@ public class JSGLR2I extends JSGLRI<IParseTable> {
 
 
     public JSGLR2I(IParserConfig config, ITermFactory termFactory, ILanguageImpl language, ILanguageImpl dialect,
-        @Nullable FileObject resource, String input, JSGLRVersion parserType) throws IOException {
-        super(config, termFactory, language, dialect, resource, input);
+        JSGLRVersion parserType) throws IOException {
+        super(config, termFactory, language, dialect);
 
         IParseTableProvider parseTableProvider = config.getParseTableProvider();
         IParseTable parseTable = getParseTable(parseTableProvider);
@@ -47,7 +47,8 @@ public class JSGLR2I extends JSGLRI<IParseTable> {
         }
     }
 
-    public ParseContrib parse(@Nullable JSGLRParserConfiguration parserConfig) throws IOException {
+    @Override public ParseContrib parse(@Nullable JSGLRParserConfiguration parserConfig, @Nullable FileObject resource,
+        String input) {
         if(parserConfig == null) {
             parserConfig = new JSGLRParserConfiguration();
         }

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLR2I.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLR2I.java
@@ -76,7 +76,7 @@ public class JSGLR2I extends JSGLRI<IParseTable> {
         return new ParseContrib(hasAst, hasAst && !hasErrors, ast, messages, duration);
     }
 
-    public Set<BadTokenException> getCollectedErrors() {
+    @Override public Set<BadTokenException> getCollectedErrors() {
         return Collections.emptySet();
     }
 }

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLR2I.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLR2I.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import javax.annotation.Nullable;
 
 import org.apache.commons.vfs2.FileObject;
+import org.metaborg.core.config.JSGLRVersion;
 import org.metaborg.core.language.ILanguageImpl;
 import org.metaborg.core.messages.IMessage;
 import org.metaborg.core.messages.MessageFactory;
@@ -17,26 +18,32 @@ import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermFactory;
 import org.spoofax.jsglr.shared.BadTokenException;
 import org.spoofax.jsglr2.JSGLR2;
-import org.spoofax.jsglr2.parsetable.ParseTableReadException;
 
 public class JSGLR2I extends JSGLRI<IParseTable> {
     private final JSGLR2<?, IStrategoTerm> parser;
 
 
     public JSGLR2I(IParserConfig config, ITermFactory termFactory, ILanguageImpl language, ILanguageImpl dialect,
-        @Nullable FileObject resource, String input, boolean dataDependent, boolean layoutSensitive)
-        throws IOException, ParseTableReadException {
+        @Nullable FileObject resource, String input, JSGLRVersion parserType) throws IOException {
         super(config, termFactory, language, dialect, resource, input);
 
         IParseTableProvider parseTableProvider = config.getParseTableProvider();
         IParseTable parseTable = getParseTable(parseTableProvider);
 
-        if(dataDependent) {
-            this.parser = JSGLR2.dataDependent(parseTable);
-        } else if(layoutSensitive) {
-            this.parser = JSGLR2.layoutSensitive(parseTable);
-        } else {
-            this.parser = JSGLR2.standard(parseTable);
+        switch(parserType) {
+            case dataDependent:
+                this.parser = JSGLR2.dataDependent(parseTable);
+                break;
+            case incremental:
+                this.parser = JSGLR2.incremental(parseTable);
+                break;
+            case layoutSensitive:
+                this.parser = JSGLR2.layoutSensitive(parseTable);
+                break;
+            case v2:
+            default:
+                this.parser = JSGLR2.standard(parseTable);
+                break;
         }
     }
 

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLRI.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLRI.java
@@ -16,29 +16,25 @@ abstract public class JSGLRI<PT> {
     protected final ITermFactory termFactory;
     protected final ILanguageImpl language;
     protected final ILanguageImpl dialect;
-    @Nullable protected final FileObject resource;
-    protected final String input;
 
-    public JSGLRI(IParserConfig config, ITermFactory termFactory, ILanguageImpl language, ILanguageImpl dialect,
-        @Nullable FileObject resource, String input) throws IOException {
+    public JSGLRI(IParserConfig config, ITermFactory termFactory, ILanguageImpl language, ILanguageImpl dialect) {
         this.config = config;
         this.termFactory = termFactory;
         this.language = language;
         this.dialect = dialect;
-        this.resource = resource;
-        this.input = input;
     }
-    
-    @SuppressWarnings("unchecked")
-    protected PT getParseTable(IParseTableProvider parseTableProvider) throws IOException {
-    		// Since JSGLR v1 and v2 use different parse table representations we have to cast here 
+
+    @SuppressWarnings("unchecked") protected PT getParseTable(IParseTableProvider parseTableProvider)
+        throws IOException {
+        // Since JSGLR v1 and v2 use different parse table representations we have to cast here
         return (PT) parseTableProvider.parseTable();
     }
 
-    abstract public ParseContrib parse(@Nullable JSGLRParserConfiguration parserConfig) throws IOException;
+    abstract public ParseContrib parse(@Nullable JSGLRParserConfiguration parserConfig, @Nullable FileObject resource,
+        String input);
 
     abstract public Set<BadTokenException> getCollectedErrors();
-    
+
     protected String getOrDefaultStartSymbol(@Nullable JSGLRParserConfiguration parserConfig) {
         if(parserConfig != null && parserConfig.overridingStartSymbol != null) {
             return parserConfig.overridingStartSymbol;
@@ -57,13 +53,5 @@ abstract public class JSGLRI<PT> {
 
     public ILanguageImpl getDialect() {
         return dialect;
-    }
-
-    @Nullable public FileObject getResource() {
-        return resource;
-    }
-
-    public String getInput() {
-        return input;
     }
 }

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLRParseService.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLRParseService.java
@@ -233,14 +233,11 @@ public class JSGLRParseService implements ISpoofaxParser, ILanguageCache, AutoCl
 
 
     private JSGLRVersion jsglrVersion(ISpoofaxInputUnit input) {
-        JSGLRVersion version = JSGLRVersion.v1;
-
-        for(ILanguageComponent langComp : input.langImpl().components()) {
-            version = langComp.config().jsglrVersion();
-            break;
-        }
-
-        return version;
+        ILanguageComponent langComp = Iterables.getFirst(input.langImpl().components(), null);
+        if(langComp == null)
+            return JSGLRVersion.v1;
+        else
+            return langComp.config().jsglrVersion();
     }
 
     private boolean hasIncrementalPTGen(ILanguageImpl impl) {

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLRParseService.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLRParseService.java
@@ -107,6 +107,13 @@ public class JSGLRParseService implements ISpoofaxParser, ILanguageCache, AutoCl
 
     }
 
+    @Override public void close() {
+        parserConfigs.clear();
+        completionParserConfigs.clear();
+        referenceParseTables.clear();
+        referenceCompletionParseTables.clear();
+    }
+
 
     private JSGLRI<?> getParser(ISpoofaxInputUnit input, JSGLRParserConfiguration parserConfig)
         throws IOException, ParseException {
@@ -264,12 +271,5 @@ public class JSGLRParseService implements ISpoofaxParser, ILanguageCache, AutoCl
                 logger.error("Could not save reference " + c + "parse table for incremental parse table generation.");
             }
         }
-    }
-
-    @Override public void close() {
-        parserConfigs.clear();
-        completionParserConfigs.clear();
-        referenceParseTables.clear();
-        referenceCompletionParseTables.clear();
     }
 }


### PR DESCRIPTION
This PR links the incremental parser created in metaborg/jsglr#29 to Spoofax Core.

For the creation of the parser, I've added a new value to the enum `JSGLRVersion`, which is now passed on to the `JSGLR2I` constructor instead of some booleans.

To make the caching of parse results possible, I've changed the `JSGLRI` class so that it no longer takes a `FileObject` and the input string as parameters to the constructor, but rather to the `parse` method.
Also, the parsers are now cached in the `JSGLRParseService` using `HashMap`s (which are properly cleaned upon request in `invalidateCache`, just like cached `IParserConfig` objects).

While I was working in the `JSGLRParseService`, I made an attempt to reduce duplicate code, because there is little difference in getting a configration for a regular parse table or a completion parse table, except that a different `HashMap` is used as cache.
I hope I didn't make mistakes in the process, but at least the `./b build all` script passes :slightly_smiling_face: 

As a last remark, while I was busy, I've hit the autoformatter for the files that I changed, using the [Eclipse style configuration](https://github.com/metaborg/spoofax-deploy/tree/master/eclipse/style) and the [Eclipse Code Formatter](https://plugins.jetbrains.com/plugin/6546-eclipse-code-formatter) plugin for IntelliJ, which generates some noise in the diff (especially in `JSGLRI` and `JSGLR1I`).