### PR TITLE
Remove ParseForest type parameter from JSGLR2 interface

### DIFF
--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLR2I.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLR2I.java
@@ -20,7 +20,7 @@ import org.spoofax.jsglr.shared.BadTokenException;
 import org.spoofax.jsglr2.JSGLR2;
 
 public class JSGLR2I extends JSGLRI<IParseTable> {
-    private final JSGLR2<?, IStrategoTerm> parser;
+    private final JSGLR2<IStrategoTerm> parser;
 
 
     public JSGLR2I(IParserConfig config, ITermFactory termFactory, ILanguageImpl language, ILanguageImpl dialect,


### PR DESCRIPTION
Necessary because of the change in metaborg/jsglr#35.

@jasperdenkers Maybe we want to move the branch pointer of `develop/jsglr2` forward to `master` before merging :slightly_smiling_face: 