### PR TITLE
Add primitive to explicate grammar injections in a term.

### DIFF
--- a/meta.lib.spoofax/trans/libspoofax/sdf/pp.str
+++ b/meta.lib.spoofax/trans/libspoofax/sdf/pp.str
@@ -8,6 +8,8 @@ rules
 
   ia-get-sort = prim("SSL_EXT_get_sort_imploder_attachment", <id>)
 
+  explicate-injections = prim("SSL_EXT_explicate_injections")
+
 signature constructors
 
   Parenthetical : Unknown -> Unknown

--- a/meta.lib.spoofax/trans/libspoofax/sdf/pp.str
+++ b/meta.lib.spoofax/trans/libspoofax/sdf/pp.str
@@ -8,7 +8,9 @@ rules
 
   ia-get-sort = prim("SSL_EXT_get_sort_imploder_attachment", <id>)
 
-  explicate-injections = prim("SSL_EXT_explicate_injections")
+  explicate-injections(mangle) = prim("SSL_EXT_explicate_injections",mangle|)
+
+  explicate-injections = explicate-injections(id)
 
 signature constructors
 

--- a/meta.lib.spoofax/trans/libspoofax/sdf/pp.str
+++ b/meta.lib.spoofax/trans/libspoofax/sdf/pp.str
@@ -8,9 +8,14 @@ rules
 
   ia-get-sort = prim("SSL_EXT_get_sort_imploder_attachment", <id>)
 
-  explicate-injections(mangle) = prim("SSL_EXT_explicate_injections",mangle|)
-
-  explicate-injections = explicate-injections(id)
+  /** Create explicit constructors for sort injections.
+   *
+   *
+   *
+   * @param inj-name: String * String -> String
+   * @type Term -> Term
+   */
+  explicate-injections(inj-name) = prim("SSL_EXT_explicate_injections",inj-name|)
 
 signature constructors
 

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/SpoofaxModule.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/SpoofaxModule.java
@@ -89,6 +89,7 @@ import org.metaborg.spoofax.core.stratego.StrategoRuntimeService;
 import org.metaborg.spoofax.core.stratego.primitive.AbsolutePathPrimitive;
 import org.metaborg.spoofax.core.stratego.primitive.CallStrategyPrimitive;
 import org.metaborg.spoofax.core.stratego.primitive.DigestPrimitive;
+import org.metaborg.spoofax.core.stratego.primitive.ExplicateInjectionsPrimitive;
 import org.metaborg.spoofax.core.stratego.primitive.GetSortNamePrimitive;
 import org.metaborg.spoofax.core.stratego.primitive.IsLanguageActivePrimitive;
 import org.metaborg.spoofax.core.stratego.primitive.LanguageComponentsPrimitive;
@@ -406,6 +407,7 @@ public class SpoofaxModule extends MetaborgModule {
         bindPrimitive(spoofaxPrimitiveLibrary, CallStrategyPrimitive.class);
         bindPrimitive(spoofaxPrimitiveLibrary, IsLanguageActivePrimitive.class);
         bindPrimitive(spoofaxPrimitiveLibrary, GetSortNamePrimitive.class);
+        bindPrimitive(spoofaxPrimitiveLibrary, ExplicateInjectionsPrimitive.class);
 
 
         final Multibinder<AbstractPrimitive> spoofaxScopeGraphLibrary =

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/primitive/ExplicateInjectionsPrimitive.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/primitive/ExplicateInjectionsPrimitive.java
@@ -1,0 +1,22 @@
+package org.metaborg.spoofax.core.stratego.primitive;
+
+import org.spoofax.interpreter.core.IContext;
+import org.spoofax.interpreter.library.AbstractPrimitive;
+import org.spoofax.interpreter.stratego.Strategy;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.jsglr.client.imploder.Injections;
+
+public class ExplicateInjectionsPrimitive extends AbstractPrimitive {
+
+    public ExplicateInjectionsPrimitive() {
+        super("SSL_EXT_explicate_injections", 0, 0);
+    }
+
+    @Override public boolean call(IContext env, Strategy[] svars, IStrategoTerm[] tvars) {
+        final Injections injections = new Injections(env.getFactory());
+        final IStrategoTerm result = injections.explicate(env.current());
+        env.setCurrent(result);
+        return true;
+    }
+
+}

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/primitive/ExplicateInjectionsPrimitive.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/primitive/ExplicateInjectionsPrimitive.java
@@ -1,6 +1,8 @@
 package org.metaborg.spoofax.core.stratego.primitive;
 
-import org.metaborg.util.functions.Function2;
+import java.util.Optional;
+
+import org.metaborg.util.functions.PartialFunction2;
 import org.spoofax.interpreter.core.IContext;
 import org.spoofax.interpreter.core.InterpreterException;
 import org.spoofax.interpreter.core.Tools;
@@ -19,17 +21,17 @@ public class ExplicateInjectionsPrimitive extends AbstractPrimitive {
 
     @Override public boolean call(IContext env, Strategy[] svars, IStrategoTerm[] tvars) throws InterpreterException {
         final Strategy sInjName = svars[0];
-        final Function2<String, String, String> injName = (sort, intoSort) -> {
+        final PartialFunction2<String, String, String> injName = (sort, intoSort) -> {
             final IStrategoTerm originalTerm = env.current();
+            final IStrategoString sortTerm = env.getFactory().makeString(sort);
+            final IStrategoString intoSortTerm = env.getFactory().makeString(intoSort);
+            final IStrategoTuple input = env.getFactory().makeTuple(sortTerm, intoSortTerm);
             try {
-                final IStrategoString sortTerm = env.getFactory().makeString(sort);
-                final IStrategoString intoSortTerm = env.getFactory().makeString(intoSort);
-                final IStrategoTuple input = env.getFactory().makeTuple(sortTerm, intoSortTerm);
                 env.setCurrent(input);
                 if(sInjName.evaluate(env)) {
-                    return Tools.asJavaString(env.current());
+                    return Optional.of(Tools.asJavaString(env.current()));
                 } else {
-                    throw new InterpreterRuntimeException(new InterpreterException("Strategy to construct injection name failed."));
+                    return Optional.empty();
                 }
             } catch(InterpreterException ex) {
                 throw new InterpreterRuntimeException(ex);

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/primitive/ExplicateInjectionsPrimitive.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/primitive/ExplicateInjectionsPrimitive.java
@@ -1,6 +1,9 @@
 package org.metaborg.spoofax.core.stratego.primitive;
 
+import org.metaborg.util.functions.Function1;
 import org.spoofax.interpreter.core.IContext;
+import org.spoofax.interpreter.core.InterpreterException;
+import org.spoofax.interpreter.core.Tools;
 import org.spoofax.interpreter.library.AbstractPrimitive;
 import org.spoofax.interpreter.stratego.Strategy;
 import org.spoofax.interpreter.terms.IStrategoTerm;
@@ -9,14 +12,50 @@ import org.spoofax.jsglr.client.imploder.Injections;
 public class ExplicateInjectionsPrimitive extends AbstractPrimitive {
 
     public ExplicateInjectionsPrimitive() {
-        super("SSL_EXT_explicate_injections", 0, 0);
+        super("SSL_EXT_explicate_injections", 1, 0);
     }
 
-    @Override public boolean call(IContext env, Strategy[] svars, IStrategoTerm[] tvars) {
-        final Injections injections = new Injections(env.getFactory());
-        final IStrategoTerm result = injections.explicate(env.current());
+    @Override public boolean call(IContext env, Strategy[] svars, IStrategoTerm[] tvars) throws InterpreterException {
+        final Strategy smangle = svars[0];
+        final Function1<String, String> mangle = (name) -> {
+            final IStrategoTerm originalTerm = env.current();
+            try {
+                env.setCurrent(env.getFactory().makeString(name));
+                if(smangle.evaluate(env)) {
+                    name = Tools.asJavaString(env.current());
+                }
+                return name;
+            } catch(InterpreterException ex) {
+                throw new InterpreterRuntimeException(ex);
+            } finally {
+                env.setCurrent(originalTerm);
+            }
+        };
+        final Injections injections = new Injections(env.getFactory(), mangle);
+        final IStrategoTerm result;
+        try {
+            result = injections.explicate(env.current());
+        } catch(InterpreterRuntimeException ex) {
+            throw ex.getCause();
+        }
         env.setCurrent(result);
         return true;
+    }
+
+    private static class InterpreterRuntimeException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        public final InterpreterException cause;
+
+        public InterpreterRuntimeException(InterpreterException cause) {
+            super(cause);
+            this.cause = cause;
+        }
+
+        @Override public synchronized InterpreterException getCause() {
+            return cause;
+        }
+
     }
 
 }


### PR DESCRIPTION
This PR adds a generic primitive that transforms a term to insert constructors
where grammar injections happened. The primitive takes a strategy argument that
should construct the name of the injection constructor from the two (original,
and target) sorts.

This PR depends on https://github.com/metaborg/jsglr/pull/37.