### PR TITLE
Dynamic class loading

### DIFF
--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/SpoofaxModule.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/SpoofaxModule.java
@@ -62,6 +62,8 @@ import org.metaborg.spoofax.core.context.IndexTaskContextFactory;
 import org.metaborg.spoofax.core.context.LegacyContextFactory;
 import org.metaborg.spoofax.core.context.constraint.MultiFileConstraintContextFactory;
 import org.metaborg.spoofax.core.context.constraint.SingleFileConstraintContextFactory;
+import org.metaborg.spoofax.core.dynamicclassloading.DynamicClassLoadingService;
+import org.metaborg.spoofax.core.dynamicclassloading.IDynamicClassLoadingService;
 import org.metaborg.spoofax.core.language.LanguageComponentFactory;
 import org.metaborg.spoofax.core.language.LanguageDiscoveryService;
 import org.metaborg.spoofax.core.language.dialect.DialectIdentifier;
@@ -360,6 +362,11 @@ public class SpoofaxModule extends MetaborgModule {
             .to(SpoofaxAnalysisService.class);
         bind(new TypeLiteral<IAnalysisService<?, ?, ?>>() {}).to(SpoofaxAnalysisService.class);
         bind(IAnalysisService.class).to(SpoofaxAnalysisService.class);
+
+        // Semantic provider
+        bind(DynamicClassLoadingService.class).in(Singleton.class);
+        bind(IDynamicClassLoadingService.class).to(DynamicClassLoadingService.class);
+        languageCacheBinder.addBinding().to(DynamicClassLoadingService.class);
 
         // Stratego runtime
         bind(StrategoRuntimeService.class).in(Singleton.class);

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/BuilderInput.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/BuilderInput.java
@@ -1,0 +1,88 @@
+package org.metaborg.spoofax.core.dynamicclassloading;
+
+import javax.annotation.Nullable;
+
+import org.apache.commons.vfs2.FileObject;
+import org.metaborg.util.resource.ResourceUtils;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.terms.StrategoString;
+import org.spoofax.terms.StrategoTuple;
+import org.spoofax.terms.TermFactory;
+
+public class BuilderInput extends StrategoTuple implements IBuilderInput<IStrategoTerm, IStrategoTerm> {
+    private final IStrategoTerm selection;
+    private final IStrategoTerm position;
+    private final IStrategoTerm ast;
+    private final @Nullable FileObject resource;
+    private final @Nullable FileObject location;
+
+    @SuppressWarnings("deprecation")
+    public BuilderInput(IStrategoTerm selection, IStrategoTerm position, IStrategoTerm ast, @Nullable FileObject resource,
+        @Nullable FileObject location) {
+        super(new IStrategoTerm[] { selection, position, ast,
+                    new StrategoString(resourceString(resource, location), TermFactory.EMPTY_LIST, IStrategoTerm.IMMUTABLE),
+                    new StrategoString(locationString(location), TermFactory.EMPTY_LIST, IStrategoTerm.IMMUTABLE) }, 
+                TermFactory.EMPTY_LIST,
+                IStrategoTerm.IMMUTABLE);
+
+        this.selection = selection;
+        this.position = position;
+        this.ast = ast;
+        this.resource = resource;
+        this.location = location;
+    }
+
+    private static String resourceString(@Nullable FileObject resource, @Nullable FileObject location) {
+        if(resource != null && location != null) {
+            return ResourceUtils.relativeName(resource.getName(), location.getName(), false);
+        } else if(resource != null) {
+            return resource.getName().getURI();
+        } else {
+            return "";
+        }
+    }
+
+    private static String locationString(@Nullable FileObject location) {
+        return location == null ? "" : location.getName().getURI();
+    }
+
+    /* (non-Javadoc)
+     * @see org.metaborg.spoofax.core.dynamicclassloading.IBuilderInput#getSelection()
+     */
+    @Override
+    public IStrategoTerm getSelection() {
+        return selection;
+    }
+
+    /* (non-Javadoc)
+     * @see org.metaborg.spoofax.core.dynamicclassloading.IBuilderInput#getPosition()
+     */
+    @Override
+    public IStrategoTerm getPosition() {
+        return position;
+    }
+
+    /* (non-Javadoc)
+     * @see org.metaborg.spoofax.core.dynamicclassloading.IBuilderInput#getAst()
+     */
+    @Override
+    public IStrategoTerm getAst() {
+        return ast;
+    }
+
+    /* (non-Javadoc)
+     * @see org.metaborg.spoofax.core.dynamicclassloading.IBuilderInput#getResource()
+     */
+    @Override
+    public @Nullable FileObject getResource() {
+        return resource;
+    }
+
+    /* (non-Javadoc)
+     * @see org.metaborg.spoofax.core.dynamicclassloading.IBuilderInput#getLocation()
+     */
+    @Override
+    public @Nullable FileObject getLocation() {
+        return location;
+    }
+}

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/BuilderInput.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/BuilderInput.java
@@ -5,9 +5,9 @@ import javax.annotation.Nullable;
 import org.apache.commons.vfs2.FileObject;
 import org.metaborg.util.resource.ResourceUtils;
 import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.ITermFactory;
 import org.spoofax.terms.StrategoString;
 import org.spoofax.terms.StrategoTuple;
-import org.spoofax.terms.TermFactory;
 
 public class BuilderInput extends StrategoTuple implements IBuilderInput<IStrategoTerm, IStrategoTerm> {
     private final IStrategoTerm selection;
@@ -16,13 +16,12 @@ public class BuilderInput extends StrategoTuple implements IBuilderInput<IStrate
     private final @Nullable FileObject resource;
     private final @Nullable FileObject location;
 
-    @SuppressWarnings("deprecation")
-    public BuilderInput(IStrategoTerm selection, IStrategoTerm position, IStrategoTerm ast, @Nullable FileObject resource,
+    public BuilderInput(ITermFactory termFactory, IStrategoTerm selection, IStrategoTerm position, IStrategoTerm ast, @Nullable FileObject resource,
         @Nullable FileObject location) {
         super(new IStrategoTerm[] { selection, position, ast,
-                    new StrategoString(resourceString(resource, location), TermFactory.EMPTY_LIST, IStrategoTerm.IMMUTABLE),
-                    new StrategoString(locationString(location), TermFactory.EMPTY_LIST, IStrategoTerm.IMMUTABLE) }, 
-                TermFactory.EMPTY_LIST,
+                    new StrategoString(resourceString(resource, location), termFactory.makeList(), IStrategoTerm.IMMUTABLE),
+                    new StrategoString(locationString(location), termFactory.makeList(), IStrategoTerm.IMMUTABLE) }, 
+                termFactory.makeList(),
                 IStrategoTerm.IMMUTABLE);
 
         this.selection = selection;

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/BuilderInput.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/BuilderInput.java
@@ -46,41 +46,26 @@ public class BuilderInput extends StrategoTuple implements IBuilderInput<IStrate
         return location == null ? "" : location.getName().getURI();
     }
 
-    /* (non-Javadoc)
-     * @see org.metaborg.spoofax.core.dynamicclassloading.IBuilderInput#getSelection()
-     */
     @Override
     public IStrategoTerm getSelection() {
         return selection;
     }
 
-    /* (non-Javadoc)
-     * @see org.metaborg.spoofax.core.dynamicclassloading.IBuilderInput#getPosition()
-     */
     @Override
     public IStrategoTerm getPosition() {
         return position;
     }
 
-    /* (non-Javadoc)
-     * @see org.metaborg.spoofax.core.dynamicclassloading.IBuilderInput#getAst()
-     */
     @Override
     public IStrategoTerm getAst() {
         return ast;
     }
 
-    /* (non-Javadoc)
-     * @see org.metaborg.spoofax.core.dynamicclassloading.IBuilderInput#getResource()
-     */
     @Override
     public @Nullable FileObject getResource() {
         return resource;
     }
 
-    /* (non-Javadoc)
-     * @see org.metaborg.spoofax.core.dynamicclassloading.IBuilderInput#getLocation()
-     */
     @Override
     public @Nullable FileObject getLocation() {
         return location;

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/DynamicClassLoader.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/DynamicClassLoader.java
@@ -1,14 +1,14 @@
-package org.metaborg.spoofax.core.stratego;
+package org.metaborg.spoofax.core.dynamicclassloading;
 
 import org.strategoxt.HybridInterpreter;
 
-public class StrategoRuntimeClassLoader extends ClassLoader {
+public class DynamicClassLoader extends ClassLoader {
     private final ClassLoader strategoClassLoader = HybridInterpreter.class.getClassLoader();
     private final Iterable<ClassLoader> additionalClassLoaders;
 
 
-    public StrategoRuntimeClassLoader(Iterable<ClassLoader> additionalClassLoaders) {
-        super(StrategoRuntimeClassLoader.class.getClassLoader());
+    public DynamicClassLoader(Iterable<ClassLoader> additionalClassLoaders) {
+        super(DynamicClassLoader.class.getClassLoader());
         this.additionalClassLoaders = additionalClassLoaders;
     }
 

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/DynamicClassLoadingFacet.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/DynamicClassLoadingFacet.java
@@ -1,4 +1,4 @@
-package org.metaborg.spoofax.core.stratego;
+package org.metaborg.spoofax.core.dynamicclassloading;
 
 import java.io.File;
 import java.io.IOException;
@@ -17,14 +17,14 @@ import com.google.common.collect.Lists;
 /**
  * Represents the Stratego runtime facet of a language.
  */
-public class StrategoRuntimeFacet implements IFacet {
-    private static final ILogger logger = LoggerUtils.logger(StrategoRuntimeFacet.class);
+public class DynamicClassLoadingFacet implements IFacet {
+    private static final ILogger logger = LoggerUtils.logger(DynamicClassLoadingFacet.class);
 
-    public final Iterable<FileObject> ctreeFiles;
-    public final Iterable<FileObject> jarFiles;
+    public final Collection<FileObject> ctreeFiles;
+    public final Collection<FileObject> jarFiles;
 
 
-    public StrategoRuntimeFacet(Iterable<FileObject> ctreeFiles, Iterable<FileObject> jarFiles) {
+    public DynamicClassLoadingFacet(Collection<FileObject> ctreeFiles, Collection<FileObject> jarFiles) {
         this.ctreeFiles = ctreeFiles;
         this.jarFiles = jarFiles;
     }
@@ -37,7 +37,7 @@ public class StrategoRuntimeFacet implements IFacet {
      * @throws IOException
      *             When a file operation fails.
      */
-    public Iterable<String> available(IResourceService resourceService) throws IOException {
+    public Collection<String> available(IResourceService resourceService) throws IOException {
         final Collection<String> errors = Lists.newLinkedList();
         for(FileObject file : ctreeFiles) {
             if(!file.exists()) {
@@ -47,13 +47,13 @@ public class StrategoRuntimeFacet implements IFacet {
         }
         for(FileObject file : jarFiles) {
             if(!file.exists()) {
-                final String message = logger.format("Stratego JAR file {} does not exist", file);
+                final String message = logger.format("JAR file {} does not exist", file);
                 errors.add(message);
             } else {
                 final File localFile = resourceService.localFile(file);
                 try(final JarFile jarFile = new JarFile(localFile, false, ZipFile.OPEN_READ)) {
                     if(!jarFile.entries().hasMoreElements()) {
-                        final String message = logger.format("Stratego JAR file {} is empty", file);
+                        final String message = logger.format("JAR file {} is empty", file);
                         errors.add(message);
                     }
                 }

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/DynamicClassLoadingFacet.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/DynamicClassLoadingFacet.java
@@ -15,17 +15,15 @@ import org.metaborg.util.log.LoggerUtils;
 import com.google.common.collect.Lists;
 
 /**
- * Represents the Stratego runtime facet of a language.
+ * Represents the DynamicClassLoading facet of a language.
  */
 public class DynamicClassLoadingFacet implements IFacet {
     private static final ILogger logger = LoggerUtils.logger(DynamicClassLoadingFacet.class);
 
-    public final Collection<FileObject> ctreeFiles;
     public final Collection<FileObject> jarFiles;
 
 
-    public DynamicClassLoadingFacet(Collection<FileObject> ctreeFiles, Collection<FileObject> jarFiles) {
-        this.ctreeFiles = ctreeFiles;
+    public DynamicClassLoadingFacet(Collection<FileObject> jarFiles) {
         this.jarFiles = jarFiles;
     }
 
@@ -39,12 +37,6 @@ public class DynamicClassLoadingFacet implements IFacet {
      */
     public Collection<String> available(IResourceService resourceService) throws IOException {
         final Collection<String> errors = Lists.newLinkedList();
-        for(FileObject file : ctreeFiles) {
-            if(!file.exists()) {
-                final String message = logger.format("Stratego CTree file {} does not exist", file);
-                errors.add(message);
-            }
-        }
         for(FileObject file : jarFiles) {
             if(!file.exists()) {
                 final String message = logger.format("JAR file {} does not exist", file);

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/DynamicClassLoadingFacetFromESV.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/DynamicClassLoadingFacetFromESV.java
@@ -1,4 +1,4 @@
-package org.metaborg.spoofax.core.stratego;
+package org.metaborg.spoofax.core.dynamicclassloading;
 
 import java.util.Set;
 
@@ -13,11 +13,11 @@ import org.spoofax.interpreter.terms.IStrategoAppl;
 
 import com.google.common.collect.Sets;
 
-public class StrategoRuntimeFacetFromESV {
-    private static final ILogger logger = LoggerUtils.logger(StrategoRuntimeFacetFromESV.class);
+public class DynamicClassLoadingFacetFromESV {
+    private static final ILogger logger = LoggerUtils.logger(DynamicClassLoadingFacetFromESV.class);
 
 
-    public static @Nullable StrategoRuntimeFacet create(IStrategoAppl esv, FileObject location) throws FileSystemException {
+    public static @Nullable DynamicClassLoadingFacet create(IStrategoAppl esv, FileObject location) throws FileSystemException {
         final Set<FileObject> strategoFiles = providerResources(esv, location);
         // Use LinkedHashSet to maintain ordering.
         final Set<FileObject> ctreeFiles = Sets.newLinkedHashSet();
@@ -40,8 +40,8 @@ public class StrategoRuntimeFacetFromESV {
         if(ctreeFiles.isEmpty() && jarFiles.isEmpty()) {
             return null;
         }
-        
-        final StrategoRuntimeFacet facet = new StrategoRuntimeFacet(ctreeFiles, jarFiles);
+
+        final DynamicClassLoadingFacet facet = new DynamicClassLoadingFacet(ctreeFiles, jarFiles);
         return facet;
     }
 

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/DynamicClassLoadingService.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/DynamicClassLoadingService.java
@@ -32,8 +32,7 @@ public class DynamicClassLoadingService implements IDynamicClassLoadingService, 
     private final Set<ClassLoader> additionalClassLoaders;
 
     private final Map<ILanguageComponent, ClassLoader> classLoaderCache = Maps.newHashMap();
-    @SuppressWarnings("rawtypes")
-    private final Map<ILanguageComponent, Map<Class, ServiceLoader>> serviceLoaderCache = Maps.newHashMap();
+    private final Map<ILanguageComponent, Map<Class<?>, ServiceLoader<?>>> serviceLoaderCache = Maps.newHashMap();
     private final Injector injector;
 
 
@@ -72,8 +71,7 @@ public class DynamicClassLoadingService implements IDynamicClassLoadingService, 
 
     @Override
     public <T> List<T> loadClasses(ILanguageComponent component, Class<T> type) throws MetaborgException {
-        @SuppressWarnings("rawtypes")
-        final Map<Class, ServiceLoader> serviceLoaderCacheLevel2;
+        final Map<Class<?>, ServiceLoader<?>> serviceLoaderCacheLevel2;
         if(serviceLoaderCache.containsKey(component)) {
             serviceLoaderCacheLevel2 = serviceLoaderCache.get(component);
             if(serviceLoaderCacheLevel2.containsKey(type)) {

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/DynamicClassLoadingService.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/DynamicClassLoadingService.java
@@ -56,16 +56,17 @@ public class DynamicClassLoadingService implements IDynamicClassLoadingService, 
         }
         T instance;
         try {
-            logger.trace("Instantiating outliner class");
+            logger.trace("Instantiating class " + className);
             instance = (T) theClass.newInstance();
             injector.injectMembers(instance);
         } catch (InstantiationException e) {
-            throw new MetaborgException("Given class was not instantiable", e);
+            throw new MetaborgException("Given class was not instantiable: " + className, e);
         } catch (IllegalAccessException e) {
-            throw new MetaborgException("Given class was not accessible", e);
+            throw new MetaborgException("Given class was not accessible: " + className, e);
         } catch (ClassCastException e) {
-            throw new MetaborgException("Given class does not implement required interface", e);
+            throw new MetaborgException("Given class does not implement required interface: " + className, e);
         }
+        logger.trace("Successfully loaded and instantiated class " + className);
         return instance;
     }
 

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/DynamicClassLoadingService.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/DynamicClassLoadingService.java
@@ -14,6 +14,7 @@ import java.util.Set;
 
 import org.apache.commons.vfs2.FileObject;
 import org.metaborg.core.MetaborgException;
+import org.metaborg.core.MetaborgRuntimeException;
 import org.metaborg.core.language.ILanguageCache;
 import org.metaborg.core.language.ILanguageComponent;
 import org.metaborg.core.language.ILanguageImpl;
@@ -45,14 +46,14 @@ public class DynamicClassLoadingService implements IDynamicClassLoadingService, 
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T> T loadClass(ILanguageComponent component, String className, Class<T> expectedType) throws MetaborgException {
+    public <T> T loadClass(ILanguageComponent component, String className, Class<T> expectedType) {
         final ClassLoader classLoader = classLoader(component);
         Class<?> theClass;
         try {
             logger.trace("Loading outliner class");
             theClass = classLoader.loadClass(className);
         } catch (ClassNotFoundException e) {
-            throw new MetaborgException("Given class was not found: " + className, e);
+            throw new MetaborgRuntimeException("Given class was not found: " + className, e);
         }
         T instance;
         try {
@@ -60,11 +61,11 @@ public class DynamicClassLoadingService implements IDynamicClassLoadingService, 
             instance = (T) theClass.newInstance();
             injector.injectMembers(instance);
         } catch (InstantiationException e) {
-            throw new MetaborgException("Given class was not instantiable: " + className, e);
+            throw new MetaborgRuntimeException("Given class was not instantiable: " + className, e);
         } catch (IllegalAccessException e) {
-            throw new MetaborgException("Given class was not accessible: " + className, e);
+            throw new MetaborgRuntimeException("Given class was not accessible: " + className, e);
         } catch (ClassCastException e) {
-            throw new MetaborgException("Given class does not implement required interface: " + className, e);
+            throw new MetaborgRuntimeException("Given class does not implement required interface: " + className, e);
         }
         logger.trace("Successfully loaded and instantiated class " + className);
         return instance;
@@ -100,7 +101,7 @@ public class DynamicClassLoadingService implements IDynamicClassLoadingService, 
         return result;
     }
 
-    private ClassLoader classLoader(ILanguageComponent component) throws MetaborgException {
+    private ClassLoader classLoader(ILanguageComponent component) {
         if(classLoaderCache.containsKey(component)) {
             return classLoaderCache.get(component);
         }
@@ -114,7 +115,7 @@ public class DynamicClassLoadingService implements IDynamicClassLoadingService, 
                 i++;
             }
         } catch (MalformedURLException e) {
-            throw new MetaborgException(e);
+            throw new MetaborgRuntimeException(e);
         }
         logger.trace("Loading jar files {}", (Object) classpath);
         URLClassLoader classLoader = new URLClassLoader(classpath, new DynamicClassLoader(additionalClassLoaders));

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/DynamicClassLoadingService.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/DynamicClassLoadingService.java
@@ -1,0 +1,138 @@
+package org.metaborg.spoofax.core.dynamicclassloading;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.Set;
+
+import org.apache.commons.vfs2.FileObject;
+import org.metaborg.core.MetaborgException;
+import org.metaborg.core.language.ILanguageCache;
+import org.metaborg.core.language.ILanguageComponent;
+import org.metaborg.core.language.ILanguageImpl;
+import org.metaborg.core.resource.IResourceService;
+import org.metaborg.util.log.ILogger;
+import org.metaborg.util.log.LoggerUtils;
+
+import com.google.common.collect.Maps;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+
+public class DynamicClassLoadingService implements IDynamicClassLoadingService, ILanguageCache {
+    private static final ILogger logger = LoggerUtils.logger(DynamicClassLoadingService.class);
+
+    private final IResourceService resourceService;
+    private final Set<ClassLoader> additionalClassLoaders;
+
+    private final Map<ILanguageComponent, ClassLoader> classLoaderCache = Maps.newHashMap();
+    @SuppressWarnings("rawtypes")
+    private final Map<ILanguageComponent, Map<Class, ServiceLoader>> serviceLoaderCache = Maps.newHashMap();
+    private final Injector injector;
+
+
+    @Inject public DynamicClassLoadingService(IResourceService resourceService,
+        Set<ClassLoader> additionalClassLoaders, Injector injector) {
+        this.resourceService = resourceService;
+        this.additionalClassLoaders = additionalClassLoaders;
+        this.injector = injector;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T loadClass(ILanguageComponent component, String className, Class<T> expectedType) throws MetaborgException {
+        final ClassLoader classLoader = classLoader(component);
+        Class<?> theClass;
+        try {
+            logger.trace("Loading outliner class");
+            theClass = classLoader.loadClass(className);
+        } catch (ClassNotFoundException e) {
+            throw new MetaborgException("Given class was not found: " + className, e);
+        }
+        T instance;
+        try {
+            logger.trace("Instantiating outliner class");
+            instance = (T) theClass.newInstance();
+            injector.injectMembers(instance);
+        } catch (InstantiationException e) {
+            throw new MetaborgException("Given class was not instantiable", e);
+        } catch (IllegalAccessException e) {
+            throw new MetaborgException("Given class was not accessible", e);
+        } catch (ClassCastException e) {
+            throw new MetaborgException("Given class does not implement required interface", e);
+        }
+        return instance;
+    }
+
+    @Override
+    public <T> List<T> loadClasses(ILanguageComponent component, Class<T> type) throws MetaborgException {
+        @SuppressWarnings("rawtypes")
+        final Map<Class, ServiceLoader> serviceLoaderCacheLevel2;
+        if(serviceLoaderCache.containsKey(component)) {
+            serviceLoaderCacheLevel2 = serviceLoaderCache.get(component);
+            if(serviceLoaderCacheLevel2.containsKey(type)) {
+                @SuppressWarnings("unchecked")
+                ServiceLoader<T> serviceLoader = (ServiceLoader<T>) serviceLoaderCacheLevel2.get(type);
+                return initializeInjectionFields(serviceLoader.iterator());
+            }
+        } else {
+            serviceLoaderCacheLevel2 = Maps.newHashMap();
+            serviceLoaderCache.put(component, serviceLoaderCacheLevel2);
+        }
+        final ClassLoader classLoader = classLoader(component);
+        final ServiceLoader<T> serviceLoader = ServiceLoader.load(type, classLoader);
+        serviceLoaderCacheLevel2.put(type, serviceLoader);
+        return initializeInjectionFields(serviceLoader.iterator());
+    }
+
+    private <T> List<T> initializeInjectionFields(Iterator<T> iterator) {
+        List<T> result = new ArrayList<>();
+        for(; iterator.hasNext();) {
+            T instance = iterator.next();
+            injector.injectMembers(instance);
+            result.add(instance);
+        }
+        return result;
+    }
+
+    private ClassLoader classLoader(ILanguageComponent component) throws MetaborgException {
+        if(classLoaderCache.containsKey(component)) {
+            return classLoaderCache.get(component);
+        }
+        final Collection<FileObject> jarFiles = component.facet(DynamicClassLoadingFacet.class).jarFiles;
+        final URL[] classpath = new URL[jarFiles.size()];
+        try {
+            int i = 0;
+            for(FileObject jar : jarFiles) {
+                final File localJar = resourceService.localFile(jar);
+                classpath[i] = localJar.toURI().toURL();
+                i++;
+            }
+        } catch (MalformedURLException e) {
+            throw new MetaborgException(e);
+        }
+        logger.trace("Loading jar files {}", (Object) classpath);
+        URLClassLoader classLoader = new URLClassLoader(classpath, new DynamicClassLoader(additionalClassLoaders));
+        classLoaderCache.put(component, classLoader);
+        return classLoader;
+    }
+
+    @Override
+    public void invalidateCache(ILanguageComponent component) {
+        serviceLoaderCache.remove(component);
+        classLoaderCache.remove(component);
+    }
+
+    @Override
+    public void invalidateCache(ILanguageImpl impl) {
+        for (ILanguageComponent component : impl.components()) {
+            invalidateCache(component);
+        }
+    }
+}

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/IBuilderInput.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/IBuilderInput.java
@@ -1,0 +1,19 @@
+package org.metaborg.spoofax.core.dynamicclassloading;
+
+import javax.annotation.Nullable;
+
+import org.apache.commons.vfs2.FileObject;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.IStrategoTuple;
+
+public interface IBuilderInput<Term, AST> {
+    Term getSelection();
+
+    Term getPosition();
+
+    AST getAst();
+
+    @Nullable FileObject getResource();
+
+    @Nullable FileObject getLocation();
+}

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/IDynamicClassLoadingService.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/IDynamicClassLoadingService.java
@@ -16,7 +16,7 @@ public interface IDynamicClassLoadingService {
      * @param expectedType
      *            the (super)type the class, which it's cast to
      * @return the class instance, instantiated with its zero-argument constructor
-     * @throws MetaborgException
+     * @throws MetaborgRuntimeException
      *             on failure to find, instantiate, access, or cast the class
      */
     <T> T loadClass(ILanguageComponent component, String className, Class<T> expectedType) throws MetaborgException;
@@ -29,7 +29,7 @@ public interface IDynamicClassLoadingService {
      * @param type
      *            the (super)type the class, which it's cast to
      * @return a lazy iterator of class instances, instantiated with their zero-argument constructor
-     * @throws MetaborgException
+     * @throws MetaborgRuntimeException
      *             on failure to find, instantiate, access, or cast the class
      */
     <T> List<T> loadClasses(ILanguageComponent component, Class<T> type) throws MetaborgException;

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/IDynamicClassLoadingService.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/dynamicclassloading/IDynamicClassLoadingService.java
@@ -1,0 +1,36 @@
+package org.metaborg.spoofax.core.dynamicclassloading;
+
+import java.util.List;
+
+import org.metaborg.core.MetaborgException;
+import org.metaborg.core.language.ILanguageComponent;
+
+public interface IDynamicClassLoadingService {
+    /**
+     * Load a class from Spoofax or a provider jar of the language component
+     * 
+     * @param component
+     *            language component that may have provider jars
+     * @param className
+     *            fully qualified class name
+     * @param expectedType
+     *            the (super)type the class, which it's cast to
+     * @return the class instance, instantiated with its zero-argument constructor
+     * @throws MetaborgException
+     *             on failure to find, instantiate, access, or cast the class
+     */
+    <T> T loadClass(ILanguageComponent component, String className, Class<T> expectedType) throws MetaborgException;
+
+    /**
+     * Load all classes of a certain type from Spoofax and/or a provider jar of the language component
+     * 
+     * @param component
+     *            language component that the transformer is in
+     * @param type
+     *            the (super)type the class, which it's cast to
+     * @return a lazy iterator of class instances, instantiated with their zero-argument constructor
+     * @throws MetaborgException
+     *             on failure to find, instantiate, access, or cast the class
+     */
+    <T> List<T> loadClasses(ILanguageComponent component, Class<T> type) throws MetaborgException;
+}

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/language/ComponentFactoryRequest.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/language/ComponentFactoryRequest.java
@@ -10,6 +10,7 @@ import org.apache.commons.vfs2.FileObject;
 import org.metaborg.core.config.ILanguageComponentConfig;
 import org.metaborg.core.language.IComponentCreationConfigRequest;
 import org.metaborg.spoofax.core.dynamicclassloading.DynamicClassLoadingFacet;
+import org.metaborg.spoofax.core.stratego.StrategoRuntimeFacet;
 import org.metaborg.spoofax.core.syntax.SyntaxFacet;
 import org.spoofax.interpreter.terms.IStrategoAppl;
 
@@ -24,6 +25,7 @@ public class ComponentFactoryRequest implements IComponentCreationConfigRequest 
     @Nullable private final IStrategoAppl esvTerm;
     @Nullable private final SyntaxFacet syntaxFacet;
     @Nullable private final DynamicClassLoadingFacet dynamicClassLoadingFacet;
+    @Nullable private final StrategoRuntimeFacet strategoRuntimeFacet;
 
 
     /**
@@ -42,7 +44,8 @@ public class ComponentFactoryRequest implements IComponentCreationConfigRequest 
      */
     public ComponentFactoryRequest(FileObject location, @Nullable ILanguageComponentConfig config,
         @Nullable IStrategoAppl esvTerm, @Nullable SyntaxFacet syntaxFacet,
-        @Nullable DynamicClassLoadingFacet dynamicClassLoadingFacet) {
+        @Nullable DynamicClassLoadingFacet dynamicClassLoadingFacet,
+        @Nullable StrategoRuntimeFacet strategoRuntimeFacet) {
         this.available = true;
         this.location = location;
         this.errors = Collections.emptyList();
@@ -51,6 +54,7 @@ public class ComponentFactoryRequest implements IComponentCreationConfigRequest 
         this.config = config;
         this.syntaxFacet = syntaxFacet;
         this.dynamicClassLoadingFacet = dynamicClassLoadingFacet;
+        this.strategoRuntimeFacet = strategoRuntimeFacet;
     }
 
     /**
@@ -72,6 +76,7 @@ public class ComponentFactoryRequest implements IComponentCreationConfigRequest 
         this.config = null;
         this.syntaxFacet = null;
         this.dynamicClassLoadingFacet = null;
+        this.strategoRuntimeFacet = null;
     }
 
     /**
@@ -165,12 +170,21 @@ public class ComponentFactoryRequest implements IComponentCreationConfigRequest 
     }
 
     /**
-     * Gets the Stratego runtime facet.
+     * Gets the DynamicClassLoading facet.
      *
-     * @return The Stratego runtime facet; or <code>null</code> when there is no Stratego runtime facet.
+     * @return The DynamicClassLoading facet; or <code>null</code> when there is no DynamicClassLoading facet.
      */
     public @Nullable DynamicClassLoadingFacet dynamicClassLoadingFacet() {
         return this.dynamicClassLoadingFacet;
+    }
+
+    /**
+     * Gets the DynamicClassLoading facet.
+     *
+     * @return The DynamicClassLoading facet; or <code>null</code> when there is no DynamicClassLoading facet.
+     */
+    public @Nullable StrategoRuntimeFacet strategoRuntimeFacet() {
+        return this.strategoRuntimeFacet;
     }
 
     /**

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/language/ComponentFactoryRequest.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/language/ComponentFactoryRequest.java
@@ -9,7 +9,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.vfs2.FileObject;
 import org.metaborg.core.config.ILanguageComponentConfig;
 import org.metaborg.core.language.IComponentCreationConfigRequest;
-import org.metaborg.spoofax.core.stratego.StrategoRuntimeFacet;
+import org.metaborg.spoofax.core.dynamicclassloading.DynamicClassLoadingFacet;
 import org.metaborg.spoofax.core.syntax.SyntaxFacet;
 import org.spoofax.interpreter.terms.IStrategoAppl;
 
@@ -23,7 +23,7 @@ public class ComponentFactoryRequest implements IComponentCreationConfigRequest 
     @Nullable private final ILanguageComponentConfig config;
     @Nullable private final IStrategoAppl esvTerm;
     @Nullable private final SyntaxFacet syntaxFacet;
-    @Nullable private final StrategoRuntimeFacet strategoRuntimeFacet;
+    @Nullable private final DynamicClassLoadingFacet dynamicClassLoadingFacet;
 
 
     /**
@@ -37,12 +37,12 @@ public class ComponentFactoryRequest implements IComponentCreationConfigRequest 
      *            The ESV term.
      * @param syntaxFacet
      *            The syntax facet.
-     * @param strategoRuntimeFacet
+     * @param dynamicClassLoadingFacet
      *            The Stratego runtime facet.
      */
     public ComponentFactoryRequest(FileObject location, @Nullable ILanguageComponentConfig config,
         @Nullable IStrategoAppl esvTerm, @Nullable SyntaxFacet syntaxFacet,
-        @Nullable StrategoRuntimeFacet strategoRuntimeFacet) {
+        @Nullable DynamicClassLoadingFacet dynamicClassLoadingFacet) {
         this.available = true;
         this.location = location;
         this.errors = Collections.emptyList();
@@ -50,7 +50,7 @@ public class ComponentFactoryRequest implements IComponentCreationConfigRequest 
         this.esvTerm = esvTerm;
         this.config = config;
         this.syntaxFacet = syntaxFacet;
-        this.strategoRuntimeFacet = strategoRuntimeFacet;
+        this.dynamicClassLoadingFacet = dynamicClassLoadingFacet;
     }
 
     /**
@@ -71,7 +71,7 @@ public class ComponentFactoryRequest implements IComponentCreationConfigRequest 
         this.esvTerm = null;
         this.config = null;
         this.syntaxFacet = null;
-        this.strategoRuntimeFacet = null;
+        this.dynamicClassLoadingFacet = null;
     }
 
     /**
@@ -169,8 +169,8 @@ public class ComponentFactoryRequest implements IComponentCreationConfigRequest 
      *
      * @return The Stratego runtime facet; or <code>null</code> when there is no Stratego runtime facet.
      */
-    public @Nullable StrategoRuntimeFacet strategoRuntimeFacet() {
-        return this.strategoRuntimeFacet;
+    public @Nullable DynamicClassLoadingFacet dynamicClassLoadingFacet() {
+        return this.dynamicClassLoadingFacet;
     }
 
     /**

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/language/LanguageComponentFactory.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/language/LanguageComponentFactory.java
@@ -21,6 +21,7 @@ import org.metaborg.core.context.IContextStrategy;
 import org.metaborg.core.context.ProjectContextStrategy;
 import org.metaborg.core.language.ComponentCreationConfig;
 import org.metaborg.core.language.IComponentCreationConfigRequest;
+import org.metaborg.core.language.IFacet;
 import org.metaborg.core.language.ILanguageComponentFactory;
 import org.metaborg.core.language.IdentificationFacet;
 import org.metaborg.core.language.LanguageContributionIdentifier;
@@ -45,21 +46,19 @@ import org.metaborg.spoofax.core.context.IndexTaskContextFactory;
 import org.metaborg.spoofax.core.context.LegacyContextFactory;
 import org.metaborg.spoofax.core.context.constraint.MultiFileConstraintContextFactory;
 import org.metaborg.spoofax.core.context.constraint.SingleFileConstraintContextFactory;
+import org.metaborg.spoofax.core.dynamicclassloading.DynamicClassLoadingFacet;
+import org.metaborg.spoofax.core.dynamicclassloading.DynamicClassLoadingFacetFromESV;
 import org.metaborg.spoofax.core.esv.ESVReader;
 import org.metaborg.spoofax.core.outline.OutlineFacet;
 import org.metaborg.spoofax.core.outline.OutlineFacetFromESV;
 import org.metaborg.spoofax.core.shell.ShellFacet;
 import org.metaborg.spoofax.core.shell.ShellFacetFromESV;
-import org.metaborg.spoofax.core.stratego.StrategoRuntimeFacet;
-import org.metaborg.spoofax.core.stratego.StrategoRuntimeFacetFromESV;
 import org.metaborg.spoofax.core.style.StylerFacet;
 import org.metaborg.spoofax.core.style.StylerFacetFromESV;
 import org.metaborg.spoofax.core.syntax.ParseFacetFromESV;
 import org.metaborg.spoofax.core.syntax.SyntaxFacet;
 import org.metaborg.spoofax.core.syntax.SyntaxFacetFromESV;
 import org.metaborg.spoofax.core.terms.ITermFactoryService;
-import org.metaborg.spoofax.core.tracing.HoverFacet;
-import org.metaborg.spoofax.core.tracing.ResolverFacet;
 import org.metaborg.spoofax.core.tracing.ResolverFacetFromESV;
 import org.metaborg.util.iterators.Iterables2;
 import org.metaborg.util.log.ILogger;
@@ -218,7 +217,7 @@ public class LanguageComponentFactory implements ILanguageComponentFactory {
         }
 
         SyntaxFacet syntaxFacet = null;
-        StrategoRuntimeFacet strategoRuntimeFacet = null;
+        DynamicClassLoadingFacet dynamicClassLoadingFacet = null;
         if(esvTerm != null) {
             try {
                 syntaxFacet = SyntaxFacetFromESV.create(esvTerm, root);
@@ -230,9 +229,9 @@ public class LanguageComponentFactory implements ILanguageComponentFactory {
             }
 
             try {
-                strategoRuntimeFacet = StrategoRuntimeFacetFromESV.create(esvTerm, root);
-                if(strategoRuntimeFacet != null) {
-                    Iterables.addAll(errors, strategoRuntimeFacet.available(resourceService));
+                dynamicClassLoadingFacet = DynamicClassLoadingFacetFromESV.create(esvTerm, root);
+                if(dynamicClassLoadingFacet != null) {
+                    Iterables.addAll(errors, dynamicClassLoadingFacet.available(resourceService));
                 }
             } catch(IOException e) {
                 exceptions.add(e);
@@ -241,7 +240,7 @@ public class LanguageComponentFactory implements ILanguageComponentFactory {
 
         final ComponentFactoryRequest request;
         if(errors.isEmpty() && exceptions.isEmpty()) {
-            request = new ComponentFactoryRequest(root, config, esvTerm, syntaxFacet, strategoRuntimeFacet);
+            request = new ComponentFactoryRequest(root, config, esvTerm, syntaxFacet, dynamicClassLoadingFacet);
         } else {
             request = new ComponentFactoryRequest(root, errors, exceptions);
         }
@@ -292,9 +291,9 @@ public class LanguageComponentFactory implements ILanguageComponentFactory {
             syntaxFacet = null;
         }
 
-        final StrategoRuntimeFacet strategoRuntimeFacet = request.strategoRuntimeFacet();
-        if(strategoRuntimeFacet != null) {
-            config.addFacet(strategoRuntimeFacet);
+        final DynamicClassLoadingFacet dynamicClassLoadingFacet = request.dynamicClassLoadingFacet();
+        if(dynamicClassLoadingFacet != null) {
+            config.addFacet(dynamicClassLoadingFacet);
         }
 
         final IStrategoAppl esvTerm = request.esvTerm();
@@ -388,12 +387,12 @@ public class LanguageComponentFactory implements ILanguageComponentFactory {
                 config.addFacet(stylerFacet);
             }
 
-            final ResolverFacet resolverFacet = ResolverFacetFromESV.createResolver(esvTerm);
+            final IFacet resolverFacet = ResolverFacetFromESV.createResolver(esvTerm);
             if(resolverFacet != null) {
                 config.addFacet(resolverFacet);
             }
 
-            final HoverFacet hoverFacet = ResolverFacetFromESV.createHover(esvTerm);
+            final IFacet hoverFacet = ResolverFacetFromESV.createHover(esvTerm);
             if(hoverFacet != null) {
                 config.addFacet(hoverFacet);
             }

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/language/LanguageComponentFactory.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/language/LanguageComponentFactory.java
@@ -53,6 +53,8 @@ import org.metaborg.spoofax.core.outline.OutlineFacet;
 import org.metaborg.spoofax.core.outline.OutlineFacetFromESV;
 import org.metaborg.spoofax.core.shell.ShellFacet;
 import org.metaborg.spoofax.core.shell.ShellFacetFromESV;
+import org.metaborg.spoofax.core.stratego.StrategoRuntimeFacet;
+import org.metaborg.spoofax.core.stratego.StrategoRuntimeFacetFromESV;
 import org.metaborg.spoofax.core.style.StylerFacet;
 import org.metaborg.spoofax.core.style.StylerFacetFromESV;
 import org.metaborg.spoofax.core.syntax.ParseFacetFromESV;
@@ -218,6 +220,7 @@ public class LanguageComponentFactory implements ILanguageComponentFactory {
 
         SyntaxFacet syntaxFacet = null;
         DynamicClassLoadingFacet dynamicClassLoadingFacet = null;
+        StrategoRuntimeFacet strategoRuntimeFacet = null;
         if(esvTerm != null) {
             try {
                 syntaxFacet = SyntaxFacetFromESV.create(esvTerm, root);
@@ -232,6 +235,15 @@ public class LanguageComponentFactory implements ILanguageComponentFactory {
                 dynamicClassLoadingFacet = DynamicClassLoadingFacetFromESV.create(esvTerm, root);
                 if(dynamicClassLoadingFacet != null) {
                     Iterables.addAll(errors, dynamicClassLoadingFacet.available(resourceService));
+                }
+            } catch(IOException e) {
+                exceptions.add(e);
+            }
+
+            try {
+                strategoRuntimeFacet = StrategoRuntimeFacetFromESV.create(esvTerm, root);
+                if(strategoRuntimeFacet != null) {
+                    Iterables.addAll(errors, strategoRuntimeFacet.available(resourceService));
                 }
             } catch(IOException e) {
                 exceptions.add(e);
@@ -294,6 +306,11 @@ public class LanguageComponentFactory implements ILanguageComponentFactory {
         final DynamicClassLoadingFacet dynamicClassLoadingFacet = request.dynamicClassLoadingFacet();
         if(dynamicClassLoadingFacet != null) {
             config.addFacet(dynamicClassLoadingFacet);
+        }
+
+        final StrategoRuntimeFacet strategoRuntimeFacet = request.strategoRuntimeFacet();
+        if(strategoRuntimeFacet != null) {
+            config.addFacet(strategoRuntimeFacet);
         }
 
         final IStrategoAppl esvTerm = request.esvTerm();

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/IStrategoCommon.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/IStrategoCommon.java
@@ -7,6 +7,7 @@ import org.metaborg.core.MetaborgException;
 import org.metaborg.core.context.IContext;
 import org.metaborg.core.language.ILanguageComponent;
 import org.metaborg.core.language.ILanguageImpl;
+import org.metaborg.spoofax.core.dynamicclassloading.BuilderInput;
 import org.spoofax.interpreter.terms.IStrategoString;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.strategoxt.HybridInterpreter;
@@ -93,7 +94,7 @@ public interface IStrategoCommon {
     /**
      * Converts a location into a Stratego string.
      * 
-     * @param localLocation
+     * @param location
      *            Location to convert.
      * @return Stratego string with location.
      */
@@ -102,9 +103,9 @@ public interface IStrategoCommon {
     /**
      * Converts a resource relative to a location into a Stratego string.
      * 
-     * @param localResource
+     * @param resource
      *            Resource to convert.
-     * @param localLocation
+     * @param location
      *            Location to convert relative to.
      * @return Stratego string with resource.
      */
@@ -123,8 +124,8 @@ public interface IStrategoCommon {
      *            Location of the input context.
      * @return A 5-tuple input term (selected, position, ast, path, project-path).
      */
-    IStrategoTerm builderInputTerm(IStrategoTerm ast, @Nullable IStrategoTerm selectedTerm,
-        @Nullable FileObject resource, @Nullable FileObject location);
+    BuilderInput builderInputTerm(IStrategoTerm ast, @Nullable IStrategoTerm selectedTerm,
+                                  @Nullable FileObject resource, @Nullable FileObject location);
 
     /**
      * Creates an input term for a builder.
@@ -137,7 +138,7 @@ public interface IStrategoCommon {
      *            Location of the input context.
      * @return A 5-tuple input term (selected, position, ast, path, project-path).
      */
-    default IStrategoTerm builderInputTerm(IStrategoTerm ast, @Nullable FileObject resource,
+    default BuilderInput builderInputTerm(IStrategoTerm ast, @Nullable FileObject resource,
         @Nullable FileObject location) {
         return builderInputTerm(ast, null, resource, location);
     }

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/IStrategoCommon.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/IStrategoCommon.java
@@ -8,6 +8,7 @@ import org.metaborg.core.context.IContext;
 import org.metaborg.core.language.ILanguageComponent;
 import org.metaborg.core.language.ILanguageImpl;
 import org.metaborg.spoofax.core.dynamicclassloading.BuilderInput;
+import org.metaborg.spoofax.core.dynamicclassloading.DynamicClassLoadingFacet;
 import org.spoofax.interpreter.terms.IStrategoString;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.strategoxt.HybridInterpreter;
@@ -161,4 +162,13 @@ public interface IStrategoCommon {
      * @return Pretty printed ATerm as a Stratego string.
      */
     IStrategoString prettyPrint(IStrategoTerm term);
+
+    /**
+     * @param component
+     *            Component to check
+     * @return if the component has a facet that refers to Stratego code
+     */
+    static boolean hasStrategoFacets(ILanguageComponent component) {
+        return component.facet(DynamicClassLoadingFacet.class) != null || component.facet(StrategoRuntimeFacet.class) != null;
+    }
 }

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/StrategoCommon.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/StrategoCommon.java
@@ -10,6 +10,8 @@ import org.metaborg.core.MetaborgException;
 import org.metaborg.core.context.IContext;
 import org.metaborg.core.language.ILanguageComponent;
 import org.metaborg.core.language.ILanguageImpl;
+import org.metaborg.spoofax.core.dynamicclassloading.BuilderInput;
+import org.metaborg.spoofax.core.dynamicclassloading.DynamicClassLoadingFacet;
 import org.metaborg.spoofax.core.terms.ITermFactoryService;
 import org.metaborg.util.log.ILogger;
 import org.metaborg.util.log.LoggerUtils;
@@ -51,7 +53,7 @@ public class StrategoCommon implements IStrategoCommon {
 
     @Override public @Nullable IStrategoTerm invoke(ILanguageComponent component, IContext context, IStrategoTerm input,
         String strategy) throws MetaborgException {
-        if(component.facet(StrategoRuntimeFacet.class) == null) {
+        if(component.facet(DynamicClassLoadingFacet.class) == null) {
             return null;
         }
         final HybridInterpreter runtime = strategoRuntimeService.runtime(component, context, true);
@@ -62,7 +64,7 @@ public class StrategoCommon implements IStrategoCommon {
         String strategy) throws MetaborgException {
         List<MetaborgException> exceptions = Lists.newArrayList();
         for(ILanguageComponent component : impl.components()) {
-            if(component.facet(StrategoRuntimeFacet.class) == null) {
+            if(component.facet(DynamicClassLoadingFacet.class) == null) {
                 continue;
             }
 
@@ -82,7 +84,7 @@ public class StrategoCommon implements IStrategoCommon {
         String strategy) throws MetaborgException {
         List<MetaborgException> exceptions = Lists.newArrayList();
         for(ILanguageComponent component : impl.components()) {
-            if(component.facet(StrategoRuntimeFacet.class) == null) {
+            if(component.facet(DynamicClassLoadingFacet.class) == null) {
                 continue;
             }
 
@@ -196,34 +198,14 @@ public class StrategoCommon implements IStrategoCommon {
         return resourceTerm;
     }
 
-    @Override public IStrategoTerm builderInputTerm(IStrategoTerm ast, @Nullable IStrategoTerm selectedTerm,
+    @Override public BuilderInput builderInputTerm(IStrategoTerm ast, @Nullable IStrategoTerm selectedTerm,
         @Nullable FileObject resource, @Nullable FileObject location) {
         final ITermFactory termFactory = termFactoryService.getGeneric();
 
         final IStrategoTerm node = selectedTerm != null ? selectedTerm : ast;
         final IStrategoTerm position = termFactory.makeList();
 
-        final String locationURI;
-        final String resourceURI;
-
-        if(resource != null && location != null) {
-            locationURI = location.getName().getURI();
-            resourceURI = ResourceUtils.relativeName(resource.getName(), location.getName(), false);
-        } else if(resource != null) {
-            locationURI = "";
-            resourceURI = resource.getName().getURI();
-        } else if(location != null) {
-            locationURI = location.getName().getURI();
-            resourceURI = "";
-        } else {
-            locationURI = "";
-            resourceURI = "";
-        }
-
-        final IStrategoString locationTerm = termFactory.makeString(locationURI);
-        final IStrategoString resourceTerm = termFactory.makeString(resourceURI);
-
-        return termFactory.makeTuple(node, position, ast, resourceTerm, locationTerm);
+        return new BuilderInput(node, position, ast, resource, location);
     }
 
     @Override public String toString(IStrategoTerm term) {

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/StrategoCommon.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/StrategoCommon.java
@@ -53,7 +53,7 @@ public class StrategoCommon implements IStrategoCommon {
 
     @Override public @Nullable IStrategoTerm invoke(ILanguageComponent component, IContext context, IStrategoTerm input,
         String strategy) throws MetaborgException {
-        if(component.facet(DynamicClassLoadingFacet.class) == null) {
+        if(!IStrategoCommon.hasStrategoFacets(component)) {
             return null;
         }
         final HybridInterpreter runtime = strategoRuntimeService.runtime(component, context, true);
@@ -64,7 +64,7 @@ public class StrategoCommon implements IStrategoCommon {
         String strategy) throws MetaborgException {
         List<MetaborgException> exceptions = Lists.newArrayList();
         for(ILanguageComponent component : impl.components()) {
-            if(component.facet(DynamicClassLoadingFacet.class) == null) {
+            if(!IStrategoCommon.hasStrategoFacets(component)) {
                 continue;
             }
 
@@ -84,7 +84,7 @@ public class StrategoCommon implements IStrategoCommon {
         String strategy) throws MetaborgException {
         List<MetaborgException> exceptions = Lists.newArrayList();
         for(ILanguageComponent component : impl.components()) {
-            if(component.facet(DynamicClassLoadingFacet.class) == null) {
+            if(!IStrategoCommon.hasStrategoFacets(component)) {
                 continue;
             }
 
@@ -99,6 +99,7 @@ public class StrategoCommon implements IStrategoCommon {
         }
         throw new AggregateMetaborgException(exceptions);
     }
+
 
     @Override public @Nullable IStrategoTerm invoke(HybridInterpreter runtime, IStrategoTerm input, String strategy)
         throws MetaborgException {

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/StrategoCommon.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/StrategoCommon.java
@@ -206,7 +206,7 @@ public class StrategoCommon implements IStrategoCommon {
         final IStrategoTerm node = selectedTerm != null ? selectedTerm : ast;
         final IStrategoTerm position = termFactory.makeList();
 
-        return new BuilderInput(node, position, ast, resource, location);
+        return new BuilderInput(termFactory, node, position, ast, resource, location);
     }
 
     @Override public String toString(IStrategoTerm term) {

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/StrategoRuntimeFacet.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/StrategoRuntimeFacet.java
@@ -1,0 +1,45 @@
+package org.metaborg.spoofax.core.stratego;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import org.apache.commons.vfs2.FileObject;
+import org.metaborg.core.language.IFacet;
+import org.metaborg.core.resource.IResourceService;
+import org.metaborg.util.log.ILogger;
+import org.metaborg.util.log.LoggerUtils;
+
+import com.google.common.collect.Lists;
+
+/**
+ * Represents the Stratego runtime facet of a language.
+ */
+public class StrategoRuntimeFacet implements IFacet {
+    private static final ILogger logger = LoggerUtils.logger(StrategoRuntimeFacet.class);
+
+    public final Collection<FileObject> ctreeFiles;
+
+
+    public StrategoRuntimeFacet(Collection<FileObject> ctreeFiles) {
+        this.ctreeFiles = ctreeFiles;
+    }
+
+
+    /**
+     * Checks if all CTree and JAR files exist, returns errors if not.
+     * 
+     * @return Errors, or empty if there are no errors.
+     * @throws IOException
+     *             When a file operation fails.
+     */
+    public Collection<String> available(IResourceService resourceService) throws IOException {
+        final Collection<String> errors = Lists.newLinkedList();
+        for(FileObject file : ctreeFiles) {
+            if(!file.exists()) {
+                final String message = logger.format("Stratego CTree file {} does not exist", file);
+                errors.add(message);
+            }
+        }
+        return errors;
+    }
+}

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/StrategoRuntimeFacetFromESV.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/StrategoRuntimeFacetFromESV.java
@@ -1,4 +1,4 @@
-package org.metaborg.spoofax.core.dynamicclassloading;
+package org.metaborg.spoofax.core.stratego;
 
 import java.util.Set;
 
@@ -13,21 +13,21 @@ import org.spoofax.interpreter.terms.IStrategoAppl;
 
 import com.google.common.collect.Sets;
 
-public class DynamicClassLoadingFacetFromESV {
-    private static final ILogger logger = LoggerUtils.logger(DynamicClassLoadingFacetFromESV.class);
+public class StrategoRuntimeFacetFromESV {
+    private static final ILogger logger = LoggerUtils.logger(StrategoRuntimeFacetFromESV.class);
 
 
-    public static @Nullable DynamicClassLoadingFacet create(IStrategoAppl esv, FileObject location) throws FileSystemException {
+    public static @Nullable StrategoRuntimeFacet create(IStrategoAppl esv, FileObject location) throws FileSystemException {
         final Set<FileObject> strategoFiles = providerResources(esv, location);
         // Use LinkedHashSet to maintain ordering.
-        final Set<FileObject> jarFiles = Sets.newLinkedHashSet();
+        final Set<FileObject> ctreeFiles = Sets.newLinkedHashSet();
         for(FileObject strategoFile : strategoFiles) {
             final String extension = strategoFile.getName().getExtension();
             switch (extension) {
-                case "jar":
-                    jarFiles.add(strategoFile);
-                    break;
                 case "ctree":
+                    ctreeFiles.add(strategoFile);
+                    break;
+                case "jar":
                     break;
                 default:
                     logger.warn("Stratego provider file {} has unknown extension {}, ignoring", strategoFile, extension);
@@ -35,11 +35,11 @@ public class DynamicClassLoadingFacetFromESV {
             }
         }
 
-        if(jarFiles.isEmpty()) {
+        if(ctreeFiles.isEmpty()) {
             return null;
         }
 
-        final DynamicClassLoadingFacet facet = new DynamicClassLoadingFacet(jarFiles);
+        final StrategoRuntimeFacet facet = new StrategoRuntimeFacet(ctreeFiles);
         return facet;
     }
 

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/StrategoRuntimeService.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/StrategoRuntimeService.java
@@ -167,8 +167,15 @@ public class StrategoRuntimeService implements IStrategoRuntimeService, AutoClos
     }
 
     private void loadFiles(HybridInterpreter runtime, ILanguageComponent component) throws MetaborgException {
-        final DynamicClassLoadingFacet facet = component.facet(DynamicClassLoadingFacet.class);
-        if(facet == null) {
+        final StrategoRuntimeFacet strategoRuntimeFacet = component.facet(StrategoRuntimeFacet.class);
+        if(strategoRuntimeFacet == null) {
+            final String message =
+                String.format("Cannot get Stratego runtime for %s, it does not have a Stratego facet", component);
+            logger.error(message);
+            throw new MetaborgException(message);
+        }
+        final DynamicClassLoadingFacet dynamicClassLoadingFacet = component.facet(DynamicClassLoadingFacet.class);
+        if(dynamicClassLoadingFacet == null) {
             final String message =
                 String.format("Cannot get Stratego runtime for %s, it does not have a Stratego facet", component);
             logger.error(message);
@@ -176,11 +183,11 @@ public class StrategoRuntimeService implements IStrategoRuntimeService, AutoClos
         }
 
         // Order is important, load CTrees first.
-        final Iterable<FileObject> ctrees = facet.ctreeFiles;
+        final Iterable<FileObject> ctrees = strategoRuntimeFacet.ctreeFiles;
         if(Iterables.size(ctrees) > 0) {
             loadCtrees(runtime, ctrees);
         }
-        final Iterable<FileObject> jars = facet.jarFiles;
+        final Iterable<FileObject> jars = dynamicClassLoadingFacet.jarFiles;
         if(Iterables.size(jars) > 0) {
             loadJars(runtime, jars);
         }

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/StrategoRuntimeService.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/StrategoRuntimeService.java
@@ -19,6 +19,8 @@ import org.metaborg.core.language.ILanguageImpl;
 import org.metaborg.core.project.IProject;
 import org.metaborg.core.project.IProjectService;
 import org.metaborg.core.resource.IResourceService;
+import org.metaborg.spoofax.core.dynamicclassloading.DynamicClassLoader;
+import org.metaborg.spoofax.core.dynamicclassloading.DynamicClassLoadingFacet;
 import org.metaborg.spoofax.core.stratego.strategies.ParseStrategoFileStrategy;
 import org.metaborg.spoofax.core.terms.ITermFactoryService;
 import org.metaborg.util.log.ILogger;
@@ -165,7 +167,7 @@ public class StrategoRuntimeService implements IStrategoRuntimeService, AutoClos
     }
 
     private void loadFiles(HybridInterpreter runtime, ILanguageComponent component) throws MetaborgException {
-        final StrategoRuntimeFacet facet = component.facet(StrategoRuntimeFacet.class);
+        final DynamicClassLoadingFacet facet = component.facet(DynamicClassLoadingFacet.class);
         if(facet == null) {
             final String message =
                 String.format("Cannot get Stratego runtime for %s, it does not have a Stratego facet", component);
@@ -194,7 +196,7 @@ public class StrategoRuntimeService implements IStrategoRuntimeService, AutoClos
                 ++i;
             }
             logger.trace("Loading jar files {}", (Object) classpath);
-            final ClassLoader classLoader = new StrategoRuntimeClassLoader(additionalClassLoaders);
+            final ClassLoader classLoader = new DynamicClassLoader(additionalClassLoaders);
             runtime.loadJars(classLoader, classpath);
         } catch(IncompatibleJarException | IOException | MetaborgRuntimeException e) {
             throw new MetaborgException("Failed to load JAR", e);

--- a/org.metaborg.spoofax.core/src/test/java/org/metaborg/spoofax/core/test/language/SpoofaxLanguageTest.java
+++ b/org.metaborg.spoofax.core/src/test/java/org/metaborg/spoofax/core/test/language/SpoofaxLanguageTest.java
@@ -52,10 +52,10 @@ public class SpoofaxLanguageTest extends LanguageServiceTest {
 
         assertIterableEquals(syntaxFacet.startSymbols, "Start");
 
-        final DynamicClassLoadingFacet strategoFacet = impl.facet(DynamicClassLoadingFacet.class);
+        final DynamicClassLoadingFacet dynamicClassLoadingFacet = impl.facet(DynamicClassLoadingFacet.class);
 
-        assertIterableEquals(strategoFacet.ctreeFiles, resourceService.resolve("res:Entity/target/metaborg/stratego.ctree"));
-        assertIterableEquals(strategoFacet.jarFiles, resourceService.resolve("res:Entity/target/metaborg/stratego-javastrat.jar"));
+        assertIterableEquals(dynamicClassLoadingFacet.ctreeFiles, resourceService.resolve("res:Entity/target/metaborg/stratego.ctree"));
+        assertIterableEquals(dynamicClassLoadingFacet.jarFiles, resourceService.resolve("res:Entity/target/metaborg/stratego-javastrat.jar"));
 
         final AnalysisFacet analysisFacet = impl.facet(AnalysisFacet.class);
 

--- a/org.metaborg.spoofax.core/src/test/java/org/metaborg/spoofax/core/test/language/SpoofaxLanguageTest.java
+++ b/org.metaborg.spoofax.core/src/test/java/org/metaborg/spoofax/core/test/language/SpoofaxLanguageTest.java
@@ -14,6 +14,7 @@ import org.metaborg.core.test.language.LanguageServiceTest;
 import org.metaborg.spoofax.core.SpoofaxModule;
 import org.metaborg.spoofax.core.analysis.AnalysisFacet;
 import org.metaborg.spoofax.core.dynamicclassloading.DynamicClassLoadingFacet;
+import org.metaborg.spoofax.core.stratego.StrategoRuntimeFacet;
 import org.metaborg.spoofax.core.syntax.SyntaxFacet;
 
 import com.google.common.collect.Iterables;
@@ -53,8 +54,9 @@ public class SpoofaxLanguageTest extends LanguageServiceTest {
         assertIterableEquals(syntaxFacet.startSymbols, "Start");
 
         final DynamicClassLoadingFacet dynamicClassLoadingFacet = impl.facet(DynamicClassLoadingFacet.class);
+        final StrategoRuntimeFacet strategoRuntimeFacet = impl.facet(StrategoRuntimeFacet.class);
 
-        assertIterableEquals(dynamicClassLoadingFacet.ctreeFiles, resourceService.resolve("res:Entity/target/metaborg/stratego.ctree"));
+        assertIterableEquals(strategoRuntimeFacet.ctreeFiles, resourceService.resolve("res:Entity/target/metaborg/stratego.ctree"));
         assertIterableEquals(dynamicClassLoadingFacet.jarFiles, resourceService.resolve("res:Entity/target/metaborg/stratego-javastrat.jar"));
 
         final AnalysisFacet analysisFacet = impl.facet(AnalysisFacet.class);

--- a/org.metaborg.spoofax.core/src/test/java/org/metaborg/spoofax/core/test/language/SpoofaxLanguageTest.java
+++ b/org.metaborg.spoofax.core/src/test/java/org/metaborg/spoofax/core/test/language/SpoofaxLanguageTest.java
@@ -1,7 +1,8 @@
 package org.metaborg.spoofax.core.test.language;
 
-import static org.junit.Assert.*;
-import static org.metaborg.core.test.Assert2.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.metaborg.core.test.Assert2.assertIterableEquals;
 
 import org.apache.commons.vfs2.FileObject;
 import org.junit.Test;
@@ -12,7 +13,7 @@ import org.metaborg.core.language.IdentificationFacet;
 import org.metaborg.core.test.language.LanguageServiceTest;
 import org.metaborg.spoofax.core.SpoofaxModule;
 import org.metaborg.spoofax.core.analysis.AnalysisFacet;
-import org.metaborg.spoofax.core.stratego.StrategoRuntimeFacet;
+import org.metaborg.spoofax.core.dynamicclassloading.DynamicClassLoadingFacet;
 import org.metaborg.spoofax.core.syntax.SyntaxFacet;
 
 import com.google.common.collect.Iterables;
@@ -51,7 +52,7 @@ public class SpoofaxLanguageTest extends LanguageServiceTest {
 
         assertIterableEquals(syntaxFacet.startSymbols, "Start");
 
-        final StrategoRuntimeFacet strategoFacet = impl.facet(StrategoRuntimeFacet.class);
+        final DynamicClassLoadingFacet strategoFacet = impl.facet(DynamicClassLoadingFacet.class);
 
         assertIterableEquals(strategoFacet.ctreeFiles, resourceService.resolve("res:Entity/target/metaborg/stratego.ctree"));
         assertIterableEquals(strategoFacet.jarFiles, resourceService.resolve("res:Entity/target/metaborg/stratego-javastrat.jar"));

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/build/LanguageSpecBuilder.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/build/LanguageSpecBuilder.java
@@ -519,12 +519,8 @@ public class LanguageSpecBuilder implements AutoCloseable {
             strJavaStratFile = null;
         }
 
-        final File javaStratClassesDir =
-            resourceService.localPath(paths.strTargetClassesJavaStratDir(config.identifier().id));
-        final File dsGeneratedClassesDir = resourceService.localPath(paths.dsTargetClassesGenerateDir());
-        final File dsManualClassesDir = resourceService.localPath(paths.dsTargetClassesManualDir());
         final List<File> strJavaStratIncludeDirs =
-            Lists.newArrayList(javaStratClassesDir, dsGeneratedClassesDir, dsManualClassesDir);
+            Lists.newArrayList(resourceService.localPath(paths.targetClassesDir()));
 
         return new PackageBuilder.Input(context, config.identifier().id, origin, strFormat, strJavaStratFile,
             strJavaStratIncludeDirs);

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/build/SpoofaxLangSpecCommonPaths.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/build/SpoofaxLangSpecCommonPaths.java
@@ -39,7 +39,7 @@ public class SpoofaxLangSpecCommonPaths extends SpoofaxCommonPaths {
     public FileObject strSrcGenJavaTransDir(String languageId) {
         final String pkg = strJavaTransPkg(languageId);
         final String pkgPath = pkg.replace('.', '/');
-        return resolve(srcGenDir(), "stratego-java", pkgPath);
+        return resolve(srcGenDir(), "java", pkgPath);
     }
 
     /**


### PR DESCRIPTION
This PR generalises the mechanism through which Stratego dynamic loads classes. These dynamically loaded classes are generated by compiling Stratego to Java in a Spoofax language project. Those classes can be dynamically loaded by Spoofax as part of a LanguageComponent, so they can be accessed during execution of Stratego code from that component. 

This generalisation is useful because it allows other parts of Spoofax to use dynamically loaded classes from languages. Therefore meta-languages other than Stratego can now generate Java code and this can be picked up in Spoofax. The eventual goal is to make sure we don't necessarily need Stratego as a glue language for everything else in a Language definition. This PR is intentionally minimal. The `java-based-services` branch contains an attempt at creating Java APIs for all editor services (defined in ESV). 

There is a related PR in [metaborg/spoofax-deploy](https://github.com/metaborg/spoofax-deploy/pull/18) that changes the source directory `src-gen/stratego-java` -- where Java files generated by the Stratego compiler are put -- into `src-gen/java` to signify the more general use. In this PR there is a similar change in the `SpoofaxCommonPaths` class. 

**Open question:** Should I change Dynsem to also generate into `src-gen/java` instead of `src-gen/ds-java`? I would like to make the change but I don't know if I should mess with Vlad's code. 

See also metaborg/spoofax-deploy#18 and metaborg/stratego#6. 