### PR TITLE
Fix NPE in Constraint Analyzer

### DIFF
--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/analysis/constraint/AbstractConstraintAnalyzer.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/analysis/constraint/AbstractConstraintAnalyzer.java
@@ -128,6 +128,7 @@ public abstract class AbstractConstraintAnalyzer implements ISpoofaxAnalyzer {
         for(ISpoofaxParseUnit input : inputs) {
             if(input.detached() || input.source() == null) {
                 logger.warn("Ignoring detached units");
+                continue;
             }
             final String source = context.resourceKey(input.source());
             if(input.valid() && input.success() && !isEmptyAST(input.ast())) {


### PR DESCRIPTION
Whenever there are input units to multi file analysis that do not have a source, a message was logged that these would be ignored. However, the code did not actually ignore them, which causes a NullPointerException when trying to get a resource key for this unit, which happens a few lines below the message (old line 132, new line 133).