### PR TITLE
Small fixes

### DIFF
--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/analysis/constraint/AbstractConstraintAnalyzer.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/analysis/constraint/AbstractConstraintAnalyzer.java
@@ -131,7 +131,9 @@ public abstract class AbstractConstraintAnalyzer implements ISpoofaxAnalyzer {
                 continue;
             }
             final String source = context.resourceKey(input.source());
-            if(input.valid() && input.success() && !isEmptyAST(input.ast())) {
+            if (!input.valid() || !input.success()) continue;
+            
+            if(!isEmptyAST(input.ast())) {
                 changed.put(source, input);
             } else {
                 removed.put(source, unitService.emptyAnalyzeUnit(input, context));

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/context/constraint/ConstraintContext.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/context/constraint/ConstraintContext.java
@@ -12,6 +12,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import org.apache.commons.io.input.ClassLoaderObjectInputStream;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.metaborg.core.MetaborgRuntimeException;
@@ -251,7 +252,7 @@ public class ConstraintContext implements IConstraintContext {
     }
 
     private State readContext(FileObject file) throws IOException, ClassNotFoundException, ClassCastException {
-        try(ObjectInputStream ois = new ObjectInputStream(file.getContent().getInputStream())) {
+        try(ObjectInputStream ois = new ClassLoaderObjectInputStream(getClass().getClassLoader(), file.getContent().getInputStream())) {
             State fileState;
             try {
                 fileState = (State) ois.readObject();


### PR DESCRIPTION
* If a file cannot be parsed, it is no longer immediately deleted from the analysis results.
* Fix loading the context failing due to deserialization errors (thanks @Gohla)