### PR TITLE
Fix SortCons styling bug: add equals and hashCode

### DIFF
--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/style/SortConsCategory.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/style/SortConsCategory.java
@@ -1,13 +1,14 @@
 package org.metaborg.spoofax.core.style;
 
+import java.util.Objects;
+
 import org.metaborg.core.style.ICategory;
 
 public class SortConsCategory implements ICategory {
     private static final long serialVersionUID = 8423515260404604295L;
-    
-	public final String sort;
-    public final String cons;
 
+    public final String sort;
+    public final String cons;
 
     public SortConsCategory(String sort, String cons) {
         this.sort = sort;
@@ -18,8 +19,20 @@ public class SortConsCategory implements ICategory {
     @Override public String name() {
         return sort + "." + cons;
     }
-    
-    
+
+    @Override public boolean equals(Object o) {
+        if(this == o)
+            return true;
+        if(o == null || getClass() != o.getClass())
+            return false;
+        SortConsCategory that = (SortConsCategory) o;
+        return Objects.equals(sort, that.sort) && Objects.equals(cons, that.cons);
+    }
+
+    @Override public int hashCode() {
+        return Objects.hash(sort, cons);
+    }
+
     @Override public String toString() {
         return name();
     }


### PR DESCRIPTION
Apparently, using `Sort.Cons = ...` in ESV coloring has been broken. A lookup in [the HashMap StylerFacet.sortConsToStyle](https://github.com/metaborg/spoofax/blob/master/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/style/StylerFacet.java#L37) would always return nothing because a new object was created to index the table, and since there was no `hashCode` method in this object, there would never be a match.