### PR TITLE
Clear tableTable and dynamicRuleTable instead of just scoping the dynamic rules

### DIFF
--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/util/StrategoExecutor.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/util/StrategoExecutor.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.metaborg.util.cmd.Arguments;
 import org.metaborg.util.log.ILogger;
 import org.metaborg.util.log.LoggerUtils;
+import org.spoofax.interpreter.library.ssl.SSLLibrary;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.strategoxt.lang.Context;
 import org.strategoxt.lang.StrategoExit;
@@ -120,7 +121,6 @@ public class StrategoExecutor {
                 log.info("Execute {} {}", name, arguments);
             }
             context.setIOAgent(tracker.agent());
-            dr_scope_all_start_0_0.instance.invoke(context, context.getFactory().makeTuple());
             final String[] args = getArgumentStrings(arguments);
             if(strategy != null) {
                 context.invokeStrategyCLI(strategy, name, args);
@@ -137,7 +137,9 @@ public class StrategoExecutor {
             }
             return new ExecutionResult(false, tracker.stdout(), tracker.stderr());
         } finally {
-            dr_scope_all_end_0_0.instance.invoke(context, context.getFactory().makeTuple());
+            SSLLibrary op = (SSLLibrary) context.getOperatorRegistry(SSLLibrary.REGISTRY_NAME);
+            op.getDynamicRuleTable().clear();
+            op.getTableTable().clear();
         }
     }
 

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/util/StrategoExecutor.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/util/StrategoExecutor.java
@@ -2,9 +2,12 @@ package org.metaborg.spoofax.meta.core.pluto.util;
 
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import org.metaborg.util.cmd.Arguments;
 import org.metaborg.util.log.ILogger;
 import org.metaborg.util.log.LoggerUtils;
+import org.spoofax.interpreter.library.IOperatorRegistry;
 import org.spoofax.interpreter.library.ssl.SSLLibrary;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.strategoxt.lang.Context;
@@ -137,9 +140,12 @@ public class StrategoExecutor {
             }
             return new ExecutionResult(false, tracker.stdout(), tracker.stderr());
         } finally {
-            SSLLibrary op = (SSLLibrary) context.getOperatorRegistry(SSLLibrary.REGISTRY_NAME);
-            op.getDynamicRuleTable().clear();
-            op.getTableTable().clear();
+            final @Nullable IOperatorRegistry registry = context.getOperatorRegistry(SSLLibrary.REGISTRY_NAME);
+            if(registry != null) {
+                final SSLLibrary sslLibrary = (SSLLibrary) registry;
+                sslLibrary.getDynamicRuleTable().clear();
+                sslLibrary.getTableTable().clear();
+            }
         }
     }
 


### PR DESCRIPTION
Needs to be tested to see if nothing breaks!
This cleans up not only dynamic rules after each execution, but also the global hashtable "tableTable" which makePermissive in particular uses extensively without cleaning up after itself. 