### PR TITLE
Fix builder transformations from components that are not compile dependencies

### DIFF
--- a/org.metaborg.core/src/main/java/org/metaborg/core/transform/TransformService.java
+++ b/org.metaborg.core/src/main/java/org/metaborg/core/transform/TransformService.java
@@ -80,6 +80,11 @@ public class TransformService<P extends IParseUnit, A extends IAnalyzeUnit, TP e
         final Iterable<TransformActionContrib> actions = actionService.actionContributions(context.language(), goal);
         final Collection<TA> results = Lists.newArrayList();
         for(TransformActionContrib action : actions) {
+        	if (!context.project().config().compileDeps().contains(action.contributor.id())) {
+        		// The action is contributed by a language component that is not a compile dependency of this project,
+        		// so we skip it.
+        		continue;
+        	}
             final TA result = transformer.transform(input, context, action, config);
             results.add(result);
         }


### PR DESCRIPTION
This prevents actions from being added to the builder's transformation that originate from language components that are not compile dependencies of the project being built.

Required for:
- metaborg/spoofax-deploy#26
- metaborg/spoofax-eclipse#16