### PR TITLE
Don't generate Typesmart when disabled (which is the default)

### DIFF
--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/build/LanguageSpecBuilder.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/build/LanguageSpecBuilder.java
@@ -498,8 +498,8 @@ public class LanguageSpecBuilder implements AutoCloseable {
             sdfModule, sdfFile, jsglrVersion, sdfVersion, sdf2tableVersion, checkOverlap, checkPriorities,
             sdfExternalDef, packSdfIncludePaths, packSdfArgs, sdfCompletionModule, sdfCompletionFile, sdfMetaModules,
             sdfMetaFiles, strFile, strStratPkg, strJavaStratPkg, strJavaStratFile, strFormat, strExternalJar,
-            strExternalJarFlags, strjIncludeDirs, strjIncludeFiles, strjArgs, languageSpec.config().strBuildSetting());
-
+            strExternalJarFlags, strjIncludeDirs, strjIncludeFiles, strjArgs, languageSpec.config().strBuildSetting(),
+            config.typesmart());
     }
 
     private PackageBuilder.Input packageBuilderInput(LanguageSpecBuildInput input, Origin origin)

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/build/main/GenerateSourcesBuilder.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/build/main/GenerateSourcesBuilder.java
@@ -103,6 +103,8 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
         public final Arguments strjArgs;
         public final StrategoBuildSetting strBuildSetting;
 
+        public final @Nullable Boolean generateTypesmart;
+
 
         public Input(SpoofaxContext context, String languageId, Collection<LanguageIdentifier> sourceDeps,
             @Nullable Boolean sdfEnabled, @Nullable String sdfModule, @Nullable File sdfFile, JSGLRVersion jsglrVersion,
@@ -113,7 +115,7 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
             @Nullable String strJavaPackage, @Nullable String strJavaStratPackage, @Nullable File strJavaStratFile,
             StrategoFormat strFormat, @Nullable File strExternalJar, @Nullable String strExternalJarFlags,
             List<File> strjIncludeDirs, List<File> strjIncludeFiles, Arguments strjArgs,
-            StrategoBuildSetting strBuildSetting) {
+            StrategoBuildSetting strBuildSetting, @Nullable Boolean generateTypesmart) {
             super(context);
             this.languageId = languageId;
             this.sdfEnabled = sdfEnabled;
@@ -143,6 +145,7 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
             this.strjIncludeFiles = strjIncludeFiles;
             this.strjArgs = strjArgs;
             this.strBuildSetting = strBuildSetting;
+            this.generateTypesmart = generateTypesmart;
         }
     }
 
@@ -547,11 +550,13 @@ public class GenerateSourcesBuilder extends SpoofaxBuilder<GenerateSourcesBuilde
             }
 
             // Typesmart
-            final File typesmartExportedFile = toFile(paths.strTypesmartExportedFile());
-            final Typesmart.Input typesmartInput =
-                new Typesmart.Input(context, input.strFile, input.strjIncludeDirs, typesmartExportedFile, sdfOrigin);
-            final Origin typesmartOrigin = Typesmart.origin(typesmartInput);
-            requireBuild(typesmartOrigin);
+            if (input.generateTypesmart != null && input.generateTypesmart) {
+                final File typesmartExportedFile = toFile(paths.strTypesmartExportedFile());
+                final Typesmart.Input typesmartInput =
+                        new Typesmart.Input(context, input.strFile, input.strjIncludeDirs, typesmartExportedFile, sdfOrigin);
+                final Origin typesmartOrigin = Typesmart.origin(typesmartInput);
+                requireBuild(typesmartOrigin);
+            }
         }
     }
 


### PR DESCRIPTION
When `typesmart: true` is _not_ specified in the `metaborg.yaml`, [it defaults to `false`](https://github.com/metaborg/spoofax/blob/0cb78518fb9512fda348d3be705b4bd3dc50a581/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/config/SpoofaxProjectConfig.java#L54). However, the Typesmart files are still generated. This PR avoids generating Typesmart files when it is disabled.

This reduces the time for a full clean build of Spoofax from 28.3 min to 19.4 min (-31%) on my machine.