### PR TITLE
Refactor tokenization

### DIFF
--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/completion/JSGLRCompletionService.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/completion/JSGLRCompletionService.java
@@ -31,16 +31,9 @@ import org.metaborg.spoofax.core.unit.ISpoofaxUnitService;
 import org.metaborg.util.iterators.Iterables2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.spoofax.interpreter.terms.ISimpleTerm;
-import org.spoofax.interpreter.terms.IStrategoAppl;
-import org.spoofax.interpreter.terms.IStrategoInt;
-import org.spoofax.interpreter.terms.IStrategoList;
-import org.spoofax.interpreter.terms.IStrategoString;
-import org.spoofax.interpreter.terms.IStrategoTerm;
-import org.spoofax.interpreter.terms.IStrategoTuple;
-import org.spoofax.interpreter.terms.ITermFactory;
+import org.spoofax.interpreter.terms.*;
 import org.spoofax.jsglr.client.imploder.IToken;
-import org.spoofax.jsglr.client.imploder.ITokens;
+import org.spoofax.jsglr.client.imploder.ITokenizer;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.jsglr.client.imploder.ListImploderAttachment;
 import org.spoofax.terms.StrategoAppl;
@@ -102,7 +95,7 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
             final FileObject location = parseInput.source();
             final Iterable<String> startSymbols = language.facet(SyntaxFacet.class).startSymbols;
             completions.addAll(completionEmptyProgram(startSymbols, inputText.length(), language, location));
-            
+
             return completions;
         }
 
@@ -283,12 +276,12 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
             for(IStrategoTerm proposalTerm : proposals) {
 
                 final IStrategoTuple tuple = TermUtils.toTuple(proposalTerm);
-                if(tuple.getSubtermCount() != 5
+                if(tuple.getSubtermCount() != 5 // @formatter:off
                     || !TermUtils.isStringAt(tuple, 0)
                     || !TermUtils.isStringAt(tuple, 1)
                     || !TermUtils.isStringAt(tuple, 2)
                     || !TermUtils.isApplAt(tuple, 3)
-                    || !TermUtils.isStringAt(tuple, 4)) {
+                    || !TermUtils.isStringAt(tuple, 4)) { // @formatter:on
                     logger.error("Unexpected proposal term {}, skipping", proposalTerm);
                     continue;
                 }
@@ -333,11 +326,12 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
             for(IStrategoTerm proposalTerm : proposals) {
 
                 final IStrategoTuple tuple = (IStrategoTuple) proposalTerm;
-                if(tuple.getSubtermCount() != 5 || !(TermUtils.isString(tuple.getSubterm(0)))
+                if(tuple.getSubtermCount() != 5 // @formatter:off
+                    || !(TermUtils.isString(tuple.getSubterm(0)))
                     || !(TermUtils.isString(tuple.getSubterm(1)))
                     || !(TermUtils.isString(tuple.getSubterm(2)))
                     || !(TermUtils.isAppl(tuple.getSubterm(3)))
-                    || !(TermUtils.isString(tuple.getSubterm(4)))) {
+                    || !(TermUtils.isString(tuple.getSubterm(4)))) { // @formatter:on
                     logger.error("Unexpected proposal term {}, skipping", proposalTerm);
                     continue;
                 }
@@ -402,11 +396,11 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
                 continue;
             }
             final IStrategoTuple tuple = TermUtils.toTuple(proposalTerm);
-            if(tuple.getSubtermCount() != 4
+            if(tuple.getSubtermCount() != 4 // @formatter:off
                 || !TermUtils.isStringAt(tuple, 0)
                 || !TermUtils.isStringAt(tuple, 1)
                 || !TermUtils.isStringAt(tuple, 2)
-                || !TermUtils.isApplAt(tuple, 3)) {
+                || !TermUtils.isApplAt(tuple, 3)) { // @formatter:on
                 logger.error("Unexpected proposal term {}, skipping", proposalTerm);
                 continue;
             }
@@ -462,11 +456,11 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
                     continue;
                 }
                 final IStrategoTuple tuple = TermUtils.toTuple(proposalTerm);
-                if(tuple.getSubtermCount() != 4
+                if(tuple.getSubtermCount() != 4 // @formatter:off
                     || !TermUtils.isStringAt(tuple, 0)
                     || !TermUtils.isStringAt(tuple, 1)
                     || !TermUtils.isStringAt(tuple, 2)
-                    || !TermUtils.isApplAt(tuple, 2)) {
+                    || !TermUtils.isApplAt(tuple, 2)) { // @formatter:on
                     logger.error("Unexpected proposal term {}, skipping", proposalTerm);
                     continue;
                 }
@@ -520,11 +514,11 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
                     continue;
                 }
                 final IStrategoTuple tuple = TermUtils.toTuple(proposalTerm);
-                if(tuple.getSubtermCount() != 4
+                if(tuple.getSubtermCount() != 4 // @formatter:off
                     || !TermUtils.isStringAt(tuple, 0)
                     || !TermUtils.isStringAt(tuple, 1)
                     || !TermUtils.isStringAt(tuple, 2)
-                    || !TermUtils.isApplAt(tuple, 3)) {
+                    || !TermUtils.isApplAt(tuple, 3)) { // @formatter:on
                     logger.error("Unexpected proposal term {}, skipping", proposalTerm);
                     continue;
                 }
@@ -565,13 +559,12 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
     }
 
     private ICompletion createCompletionReplaceTerm(String name, String text, String additionalInfo,
-                                                    IStrategoAppl change, boolean blankLineCompletion, String prefix, String suffix) {
+        IStrategoAppl change, boolean blankLineCompletion, String prefix, String suffix) {
 
         final IStrategoTerm oldNode = change.getSubterm(0);
         final IStrategoTerm newNode = change.getSubterm(1);
 
-        if(change.getSubtermCount() != 2 || !(TermUtils.isAppl(newNode))
-            || !(TermUtils.isAppl(oldNode))) {
+        if(change.getSubtermCount() != 2 || !(TermUtils.isAppl(newNode)) || !(TermUtils.isAppl(oldNode))) {
             return null;
         }
 
@@ -580,7 +573,7 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
         int insertionPoint, suffixPoint;
 
         final ImploderAttachment oldNodeIA = oldNode.getAttachment(ImploderAttachment.TYPE);
-        ITokens tokenizer = ImploderAttachment.getTokenizer(oldNode);
+        ITokenizer tokenizer = (ITokenizer) ImploderAttachment.getTokenizer(oldNode);
 
         // check if it's an empty node
         if(oldNodeIA.getLeftToken().getStartOffset() > oldNodeIA.getRightToken().getEndOffset()) {
@@ -657,7 +650,7 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
 
         int insertionPoint, suffixPoint;
 
-        ITokens tokenizer = ImploderAttachment.getTokenizer(oldNode);
+        ITokenizer tokenizer = (ITokenizer) ImploderAttachment.getTokenizer(oldNode);
 
         IStrategoTerm[] subterms = oldList.getAllSubterms();
         int indexOfElement;
@@ -723,8 +716,7 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
         final IStrategoTerm newNode = change.getSubterm(1);
 
         // expected two lists
-        if(change.getSubtermCount() != 2 || !TermUtils.isList(oldNode)
-            || !TermUtils.isList(newNode)) {
+        if(change.getSubtermCount() != 2 || !TermUtils.isList(oldNode) || !TermUtils.isList(newNode)) {
             return null;
         }
 
@@ -732,7 +724,7 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
 
         int insertionPoint, suffixPoint;
 
-        ITokens tokenizer = ImploderAttachment.getTokenizer(oldNode);
+        ITokenizer tokenizer = (ITokenizer) ImploderAttachment.getTokenizer(oldNode);
         final ImploderAttachment oldListIA = oldNode.getAttachment(ImploderAttachment.TYPE);
         int tokenPosition;
         // if list is empty
@@ -850,13 +842,13 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
                     continue;
                 }
                 final IStrategoTuple tuple = TermUtils.toTuple(proposalTerm);
-                if(tuple.getSubtermCount() != 6
+                if(tuple.getSubtermCount() != 6 // @formatter:off
                     || !TermUtils.isStringAt(tuple, 0)
                     || !TermUtils.isStringAt(tuple, 1)
                     || !TermUtils.isStringAt(tuple, 2)
                     || !TermUtils.isApplAt(tuple, 3)
                     || (tuple.getSubterm(4) == null)
-                    || !TermUtils.isStringAt(tuple, 5)) {
+                    || !TermUtils.isStringAt(tuple, 5)) { // @formatter:on
                     logger.error("Unexpected proposal term {}, skipping", proposalTerm);
                     continue;
                 }
@@ -927,9 +919,9 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
     private String calculatePrefix(int cursorPosition, IStrategoTerm proposalTerm) {
 
         String prefix = "";
-        ITokens tokenizer = proposalTerm.getAttachment(ImploderAttachment.TYPE).getLeftToken().getTokenizer();
         IToken leftToken = proposalTerm.getAttachment(ImploderAttachment.TYPE).getLeftToken();
         IToken rightToken = proposalTerm.getAttachment(ImploderAttachment.TYPE).getRightToken();
+        ITokenizer tokenizer = (ITokenizer) leftToken.getTokenizer();
         IToken current = leftToken;
         int endOffsetPrefix = Integer.MIN_VALUE;
         while(current.getEndOffset() < cursorPosition && current != rightToken) {
@@ -947,9 +939,9 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
     private String calculateSuffix(int cursorPosition, IStrategoTerm proposalTerm) {
 
         String suffix = "";
-        ITokens tokenizer = proposalTerm.getAttachment(ImploderAttachment.TYPE).getLeftToken().getTokenizer();
         IToken leftToken = proposalTerm.getAttachment(ImploderAttachment.TYPE).getLeftToken();
         IToken rightToken = proposalTerm.getAttachment(ImploderAttachment.TYPE).getRightToken();
+        ITokenizer tokenizer = (ITokenizer) leftToken.getTokenizer();
         IToken current = rightToken;
         int startOffsetSuffix = Integer.MAX_VALUE;
         while(current.getStartOffset() >= cursorPosition && current != leftToken) {
@@ -976,7 +968,7 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
 
         int insertionPoint, suffixPoint;
 
-        ITokens tokenizer = ImploderAttachment.getTokenizer(newNode);
+        ITokenizer tokenizer = (ITokenizer) ImploderAttachment.getTokenizer(newNode);
 
         final IStrategoTerm topMostAmb = findTopMostAmbNode(newNode);
         final ImploderAttachment topMostAmbIA = topMostAmb.getAttachment(ImploderAttachment.TYPE);
@@ -1044,7 +1036,7 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
         // if inserted element is first (only two elements)
         if(indexOfCompletion == 1) {
             // insert after the first non-layout token before the leftmost token of the list
-            ITokens tokenizer = ImploderAttachment.getTokenizer(oldList);
+            ITokenizer tokenizer = (ITokenizer) ImploderAttachment.getTokenizer(oldList);
 
             // to avoid keeping duplicate tokens due to ambiguity
             IStrategoTerm topMostAmbOldList = findTopMostAmbNode(oldList);
@@ -1090,15 +1082,14 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
         final IStrategoTerm oldNodeTopMostAmb = findTopMostAmbNode(oldNode);
 
 
-        if(change.getSubtermCount() != 2 || !(TermUtils.isList(oldNode))
-            || !(TermUtils.isAppl(newNode))) {
+        if(change.getSubtermCount() != 2 || !(TermUtils.isList(oldNode)) || !(TermUtils.isAppl(newNode))) {
             return null;
         }
 
         final String sort = ImploderAttachment.getElementSort(oldNode);
 
         int insertionPoint, suffixPoint;
-        ITokens tokenizer = ImploderAttachment.getTokenizer(oldNodeTopMostAmb);
+        ITokenizer tokenizer = (ITokenizer) ImploderAttachment.getTokenizer(oldNodeTopMostAmb);
         final ImploderAttachment oldNodeIA = oldNodeTopMostAmb.getAttachment(ImploderAttachment.TYPE);
 
         // if list is empty
@@ -1255,8 +1246,7 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
         HybridInterpreter runtime) throws MetaborgException {
         Collection<IStrategoTerm> inputsStratego = Lists.newLinkedList();
 
-        Collection<IStrategoTerm> nestedCompletionTerms =
-            findNestedCompletionTerm(nestedCompletionTerm, true);
+        Collection<IStrategoTerm> nestedCompletionTerms = findNestedCompletionTerm(nestedCompletionTerm, true);
 
         for(IStrategoTerm innerNestedCompletionTerm : nestedCompletionTerms) {
             Collection<IStrategoTerm> inputsStrategoInnerNested = calculateNestedCompletionProposals(
@@ -1362,8 +1352,7 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
         final IStrategoTerm newNode = change.getSubterm(1);
 
 
-        if(change.getSubtermCount() != 2 || !(TermUtils.isAppl(newNode))
-            || !(TermUtils.isAppl(oldNode))) {
+        if(change.getSubtermCount() != 2 || !(TermUtils.isAppl(newNode)) || !(TermUtils.isAppl(oldNode))) {
             return null;
         }
 
@@ -1372,7 +1361,7 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
         int insertionPoint, suffixPoint;
 
         final ImploderAttachment oldNodeIA = oldNode.getAttachment(ImploderAttachment.TYPE);
-        ITokens tokenizer = ImploderAttachment.getTokenizer(oldNode);
+        ITokenizer tokenizer = (ITokenizer) ImploderAttachment.getTokenizer(oldNode);
 
         // check if it's an empty node
         if(oldNodeIA.getLeftToken().getStartOffset() > oldNodeIA.getRightToken().getEndOffset()) {
@@ -1589,10 +1578,10 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
         final FileObject resource = SourceAttachment.getResource(fragment, resourceService);
         final IToken left = ImploderAttachment.getLeftToken(fragment);
         final IToken right = ImploderAttachment.getRightToken(fragment);
-        ITokens tokenizer = ImploderAttachment.getTokenizer(fragment);
+        ITokenizer tokenizer = (ITokenizer) ImploderAttachment.getTokenizer(fragment);
         IToken leftmostValid = left;
         IToken rightmostValid = right;
-        boolean isList = (TermUtils.isList(fragment)) ? true : false;
+        boolean isList = TermUtils.isList(fragment);
         boolean isOptional = false;
         String sort = ImploderAttachment.getSort(fragment);
         IStrategoTerm input = termFactory.makeString(sort);

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/completion/JSGLRCompletionService.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/completion/JSGLRCompletionService.java
@@ -51,6 +51,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 
+import static org.spoofax.jsglr.client.imploder.IToken.Kind.*;
+
 public class JSGLRCompletionService implements ISpoofaxCompletionService {
     private static final Logger logger = LoggerFactory.getLogger(JSGLRCompletionService.class);
 
@@ -580,8 +582,8 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
             // get the last non-layout token before the new node
             int tokenPosition =
                 oldNodeIA.getLeftToken().getIndex() - 1 > 0 ? oldNodeIA.getLeftToken().getIndex() - 1 : 0;
-            while(tokenPosition > 0 && (tokenizer.getTokenAt(tokenPosition).getKind() == IToken.TK_LAYOUT
-                || tokenizer.getTokenAt(tokenPosition).getKind() == IToken.TK_ERROR))
+            while(tokenPosition > 0 && (tokenizer.getTokenAt(tokenPosition).getKind() == TK_LAYOUT
+                || tokenizer.getTokenAt(tokenPosition).getKind() == TK_ERROR))
                 tokenPosition--;
             insertionPoint = tokenizer.getTokenAt(tokenPosition).getEndOffset();
 
@@ -590,8 +592,8 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
                 tokenPosition = oldNodeIA.getLeftToken().getIndex() + 1 < tokenizer.getTokenCount()
                     ? oldNodeIA.getLeftToken().getIndex() + 1 : tokenizer.getTokenCount() - 1;
                 while(tokenPosition < tokenizer.getTokenCount()
-                    && (tokenizer.getTokenAt(tokenPosition).getKind() == IToken.TK_LAYOUT
-                        || tokenizer.getTokenAt(tokenPosition).getKind() == IToken.TK_ERROR))
+                    && (tokenizer.getTokenAt(tokenPosition).getKind() == TK_LAYOUT
+                        || tokenizer.getTokenAt(tokenPosition).getKind() == TK_ERROR))
                     tokenPosition++;
                 suffixPoint = tokenizer.getTokenAt(tokenPosition).getStartOffset();
             } else { // if completion spams multiple lines keep the lines
@@ -666,8 +668,8 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
             final ImploderAttachment oldNodeIA = oldNode.getAttachment(ImploderAttachment.TYPE);
             int tokenPosition =
                 oldNodeIA.getLeftToken().getIndex() - 1 > 0 ? oldNodeIA.getLeftToken().getIndex() - 1 : 0;
-            while((tokenizer.getTokenAt(tokenPosition).getKind() == IToken.TK_LAYOUT
-                || tokenizer.getTokenAt(tokenPosition).getKind() == IToken.TK_ERROR) && tokenPosition > 0)
+            while((tokenizer.getTokenAt(tokenPosition).getKind() == TK_LAYOUT
+                || tokenizer.getTokenAt(tokenPosition).getKind() == TK_ERROR) && tokenPosition > 0)
                 tokenPosition--;
 
             insertionPoint = tokenizer.getTokenAt(tokenPosition).getEndOffset();
@@ -732,8 +734,8 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
         // node
         if(oldNode.getSubtermCount() == 0) {
             tokenPosition = oldListIA.getLeftToken().getIndex() - 1 > 0 ? oldListIA.getLeftToken().getIndex() - 1 : 0;
-            while((tokenizer.getTokenAt(tokenPosition).getKind() == IToken.TK_LAYOUT
-                || tokenizer.getTokenAt(tokenPosition).getKind() == IToken.TK_ERROR) && tokenPosition > 0)
+            while((tokenizer.getTokenAt(tokenPosition).getKind() == TK_LAYOUT
+                || tokenizer.getTokenAt(tokenPosition).getKind() == TK_ERROR) && tokenPosition > 0)
                 tokenPosition--;
             insertionPoint = tokenizer.getTokenAt(tokenPosition).getEndOffset();
         } else {
@@ -743,7 +745,7 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
             IStrategoTerm elementBefore = oldNode.getSubterm(oldNode.getAllSubterms().length - 1);
             int leftIdx = elementBefore.getAttachment(ImploderAttachment.TYPE).getLeftToken().getIndex();
             int rightIdx = elementBefore.getAttachment(ImploderAttachment.TYPE).getRightToken().getIndex();
-            while((tokenizer.getTokenAt(rightIdx).getKind() == IToken.TK_LAYOUT
+            while((tokenizer.getTokenAt(rightIdx).getKind() == TK_LAYOUT
                 || tokenizer.getTokenAt(rightIdx).getLength() == 0) && rightIdx > leftIdx) {
                 rightIdx--;
             }
@@ -976,8 +978,8 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
         // get the last non-layout token before the topmost ambiguity
         int tokenPosition =
             topMostAmbIA.getLeftToken().getIndex() - 1 > 0 ? topMostAmbIA.getLeftToken().getIndex() - 1 : 0;
-        while((tokenizer.getTokenAt(tokenPosition).getKind() == IToken.TK_LAYOUT
-            || tokenizer.getTokenAt(tokenPosition).getKind() == IToken.TK_ERROR) && tokenPosition > 0)
+        while((tokenizer.getTokenAt(tokenPosition).getKind() == TK_LAYOUT
+            || tokenizer.getTokenAt(tokenPosition).getKind() == TK_ERROR) && tokenPosition > 0)
             tokenPosition--;
 
         insertionPoint = tokenizer.getTokenAt(tokenPosition).getEndOffset();
@@ -988,7 +990,7 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
             tokenPosition = topMostAmbIA.getRightToken().getIndex();
             while(tokenPosition > 0
                 && (tokenizer.getTokenAt(tokenPosition).getEndOffset() < tokenizer.getTokenAt(tokenPosition)
-                    .getStartOffset() || tokenizer.getTokenAt(tokenPosition).getKind() == IToken.TK_LAYOUT))
+                    .getStartOffset() || tokenizer.getTokenAt(tokenPosition).getKind() == TK_LAYOUT))
                 tokenPosition--;
             suffixPoint = tokenizer.getTokenAt(tokenPosition).getEndOffset() + 1;
 
@@ -1045,8 +1047,8 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
             int tokenPosition =
                 oldListIA.getLeftToken().getIndex() - 1 > 0 ? oldListIA.getLeftToken().getIndex() - 1 : 0;
             while((checkEmptyOffset(tokenizer.getTokenAt(tokenPosition))
-                || tokenizer.getTokenAt(tokenPosition).getKind() == IToken.TK_LAYOUT
-                || tokenizer.getTokenAt(tokenPosition).getKind() == IToken.TK_ERROR) && tokenPosition > 0)
+                || tokenizer.getTokenAt(tokenPosition).getKind() == TK_LAYOUT
+                || tokenizer.getTokenAt(tokenPosition).getKind() == TK_ERROR) && tokenPosition > 0)
                 tokenPosition--;
 
             insertionPoint = tokenizer.getTokenAt(tokenPosition).getEndOffset();
@@ -1098,8 +1100,8 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
             int tokenPosition =
                 oldNodeIA.getLeftToken().getIndex() - 1 > 0 ? oldNodeIA.getLeftToken().getIndex() - 1 : 0;
             while(tokenPosition > 0 && (checkEmptyOffset(tokenizer.getTokenAt(tokenPosition))
-                || tokenizer.getTokenAt(tokenPosition).getKind() == IToken.TK_LAYOUT
-                || tokenizer.getTokenAt(tokenPosition).getKind() == IToken.TK_ERROR))
+                || tokenizer.getTokenAt(tokenPosition).getKind() == TK_LAYOUT
+                || tokenizer.getTokenAt(tokenPosition).getKind() == TK_ERROR))
                 tokenPosition--;
             insertionPoint = tokenizer.getTokenAt(tokenPosition).getEndOffset();
         } else {
@@ -1112,7 +1114,7 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
         // keep all the characters after the last non-layout token
         int tokenPosition = oldNodeIA.getRightToken().getIndex();
         while(tokenizer.getTokenAt(tokenPosition).getEndOffset() < tokenizer.getTokenAt(tokenPosition).getStartOffset()
-            || tokenizer.getTokenAt(tokenPosition).getKind() == IToken.TK_LAYOUT && tokenPosition > 0)
+            || tokenizer.getTokenAt(tokenPosition).getKind() == TK_LAYOUT && tokenPosition > 0)
             tokenPosition--;
         suffixPoint = tokenizer.getTokenAt(tokenPosition).getEndOffset() + 1;
 
@@ -1368,8 +1370,8 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
             // get the last non-layout token before the new node
             int tokenPosition =
                 oldNodeIA.getLeftToken().getIndex() - 1 > 0 ? oldNodeIA.getLeftToken().getIndex() - 1 : 0;
-            while((tokenizer.getTokenAt(tokenPosition).getKind() == IToken.TK_LAYOUT
-                || tokenizer.getTokenAt(tokenPosition).getKind() == IToken.TK_ERROR) && tokenPosition > 0)
+            while((tokenizer.getTokenAt(tokenPosition).getKind() == TK_LAYOUT
+                || tokenizer.getTokenAt(tokenPosition).getKind() == TK_ERROR) && tokenPosition > 0)
                 tokenPosition--;
             insertionPoint = tokenizer.getTokenAt(tokenPosition).getEndOffset();
         } else { // if not, do a regular replacement
@@ -1381,8 +1383,8 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
         int tokenPositionEnd = oldNodeIA.getRightToken().getIndex();
 
         while((tokenizer.getTokenAt(tokenPositionEnd).getEndOffset() < tokenizer.getTokenAt(tokenPositionEnd)
-            .getStartOffset() || tokenizer.getTokenAt(tokenPositionEnd).getKind() == IToken.TK_LAYOUT
-            || tokenizer.getTokenAt(tokenPositionEnd).getKind() == IToken.TK_ERROR) && tokenPositionEnd > 0)
+            .getStartOffset() || tokenizer.getTokenAt(tokenPositionEnd).getKind() == TK_LAYOUT
+            || tokenizer.getTokenAt(tokenPositionEnd).getKind() == TK_ERROR) && tokenPositionEnd > 0)
             tokenPositionEnd--;
 
         suffixPoint = tokenizer.getTokenAt(tokenPositionEnd).getEndOffset() + 1;
@@ -1628,8 +1630,8 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
         if(left.getStartOffset() > right.getEndOffset() || isList || isOptional
             || (isLeftRecursive && isRightRecursive)) {
             for(int i = left.getIndex() - 1; i >= 0; i--) {
-                if(tokenizer.getTokenAt(i).getKind() == IToken.TK_LAYOUT
-                    || tokenizer.getTokenAt(i).getKind() == IToken.TK_ERROR) {
+                if(tokenizer.getTokenAt(i).getKind() == TK_LAYOUT
+                    || tokenizer.getTokenAt(i).getKind() == TK_ERROR) {
                     leftmostValid = tokenizer.getTokenAt(i);
                 } else {
                     break;
@@ -1637,9 +1639,9 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
             }
 
             for(int i = right.getIndex() + 1; i < tokenizer.getTokenCount(); i++) {
-                if(tokenizer.getTokenAt(i).getKind() == IToken.TK_LAYOUT
-                    || tokenizer.getTokenAt(i).getKind() == IToken.TK_EOF
-                    || tokenizer.getTokenAt(i).getKind() == IToken.TK_ERROR) {
+                if(tokenizer.getTokenAt(i).getKind() == TK_LAYOUT
+                    || tokenizer.getTokenAt(i).getKind() == TK_EOF
+                    || tokenizer.getTokenAt(i).getKind() == TK_ERROR) {
                     rightmostValid = tokenizer.getTokenAt(i);
                 } else {
                     break;
@@ -1648,8 +1650,8 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
             // if it is left recursive include the layout only on the right
         } else if(isLeftRecursive) {
             for(int i = left.getIndex(); i < right.getIndex(); i++) {
-                if(tokenizer.getTokenAt(i).getKind() == IToken.TK_LAYOUT
-                    || tokenizer.getTokenAt(i).getKind() == IToken.TK_ERROR) {
+                if(tokenizer.getTokenAt(i).getKind() == TK_LAYOUT
+                    || tokenizer.getTokenAt(i).getKind() == TK_ERROR) {
                     leftmostValid = tokenizer.getTokenAt(i + 1);
                 } else {
                     break;
@@ -1657,9 +1659,9 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
             }
 
             for(int i = right.getIndex() + 1; i < tokenizer.getTokenCount(); i++) {
-                if(tokenizer.getTokenAt(i).getKind() == IToken.TK_LAYOUT
-                    || tokenizer.getTokenAt(i).getKind() == IToken.TK_EOF
-                    || tokenizer.getTokenAt(i).getKind() == IToken.TK_ERROR) {
+                if(tokenizer.getTokenAt(i).getKind() == TK_LAYOUT
+                    || tokenizer.getTokenAt(i).getKind() == TK_EOF
+                    || tokenizer.getTokenAt(i).getKind() == TK_ERROR) {
                     rightmostValid = tokenizer.getTokenAt(i);
                 } else {
                     break;
@@ -1669,8 +1671,8 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
             // if it is right recursive include the layout only on the left
         } else if(isRightRecursive) {
             for(int i = left.getIndex() - 1; i >= 0; i--) {
-                if(tokenizer.getTokenAt(i).getKind() == IToken.TK_LAYOUT
-                    || tokenizer.getTokenAt(i).getKind() == IToken.TK_ERROR) {
+                if(tokenizer.getTokenAt(i).getKind() == TK_LAYOUT
+                    || tokenizer.getTokenAt(i).getKind() == TK_ERROR) {
                     leftmostValid = tokenizer.getTokenAt(i);
                 } else {
                     break;
@@ -1678,9 +1680,9 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
             }
 
             for(int i = right.getIndex(); i > left.getIndex(); i--) {
-                if(tokenizer.getTokenAt(i).getKind() == IToken.TK_LAYOUT
-                    || tokenizer.getTokenAt(i).getKind() == IToken.TK_EOF
-                    || tokenizer.getTokenAt(i).getKind() == IToken.TK_ERROR) {
+                if(tokenizer.getTokenAt(i).getKind() == TK_LAYOUT
+                    || tokenizer.getTokenAt(i).getKind() == TK_EOF
+                    || tokenizer.getTokenAt(i).getKind() == TK_ERROR) {
                     rightmostValid = tokenizer.getTokenAt(i - 1);
                 } else {
                     break;
@@ -1691,8 +1693,8 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
         // if not make it stripes the surrounding layout tokens
         else {
             for(int i = left.getIndex(); i < right.getIndex(); i++) {
-                if(tokenizer.getTokenAt(i).getKind() == IToken.TK_LAYOUT
-                    || tokenizer.getTokenAt(i).getKind() == IToken.TK_ERROR) {
+                if(tokenizer.getTokenAt(i).getKind() == TK_LAYOUT
+                    || tokenizer.getTokenAt(i).getKind() == TK_ERROR) {
                     leftmostValid = tokenizer.getTokenAt(i + 1);
                 } else {
                     break;
@@ -1700,9 +1702,9 @@ public class JSGLRCompletionService implements ISpoofaxCompletionService {
             }
 
             for(int i = right.getIndex(); i > left.getIndex(); i--) {
-                if(tokenizer.getTokenAt(i).getKind() == IToken.TK_LAYOUT
-                    || tokenizer.getTokenAt(i).getKind() == IToken.TK_EOF
-                    || tokenizer.getTokenAt(i).getKind() == IToken.TK_ERROR) {
+                if(tokenizer.getTokenAt(i).getKind() == TK_LAYOUT
+                    || tokenizer.getTokenAt(i).getKind() == TK_EOF
+                    || tokenizer.getTokenAt(i).getKind() == TK_ERROR) {
                     rightmostValid = tokenizer.getTokenAt(i - 1);
                 } else {
                     break;

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/style/CategorizerService.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/style/CategorizerService.java
@@ -18,9 +18,9 @@ import org.spoofax.jsglr.client.imploder.IToken;
 import org.spoofax.jsglr.client.imploder.ITokens;
 import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.terms.attachments.ParentAttachment;
+import org.spoofax.terms.util.TermUtils;
 
 import com.google.common.collect.Lists;
-import org.spoofax.terms.util.TermUtils;
 
 public class CategorizerService implements ISpoofaxCategorizerService {
     private static final ILogger logger = LoggerUtils.logger(CategorizerService.class);
@@ -53,22 +53,7 @@ public class CategorizerService implements ISpoofaxCategorizerService {
             // GTODO: throw exception instead
             return regionCategories;
         }
-        int offset = -1;
-        for (IToken token : tokenizer) {
-            if(tokenizer.isAmbiguous() && token.getStartOffset() < offset) {
-                // In case of ambiguities, tokens inside the ambiguity are duplicated, ignore.
-                continue;
-            }
-            if(token.getStartOffset() > token.getEndOffset()) {
-                // Indicates an invalid region. Empty lists have regions like this.
-                continue;
-            }
-            if(offset >= token.getStartOffset()) {
-                // Duplicate region, skip.
-                continue;
-            }
-            offset = token.getEndOffset();
-
+        for(IToken token : tokenizer) {
             final ICategory category = category(facet, token);
             if(category != null) {
                 final ISourceRegion region = JSGLRSourceRegionFactory.fromToken(token);

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/style/CategorizerService.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/style/CategorizerService.java
@@ -53,10 +53,8 @@ public class CategorizerService implements ISpoofaxCategorizerService {
             // GTODO: throw exception instead
             return regionCategories;
         }
-        final int tokenCount = tokenizer.getTokenCount();
         int offset = -1;
-        for(int i = 0; i < tokenCount; ++i) {
-            final IToken token = tokenizer.getTokenAt(i);
+        for (IToken token : tokenizer) {
             if(tokenizer.isAmbiguous() && token.getStartOffset() < offset) {
                 // In case of ambiguities, tokens inside the ambiguity are duplicated, ignore.
                 continue;

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/style/CategorizerService.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/style/CategorizerService.java
@@ -140,31 +140,31 @@ public class CategorizerService implements ISpoofaxCategorizerService {
 
     private ICategory tokenCategory(IToken token) {
         switch(token.getKind()) {
-            case IToken.TK_IDENTIFIER:
+            case TK_IDENTIFIER:
                 return new TokenCategory("TK_IDENTIFIER");
-            case IToken.TK_NUMBER:
+            case TK_NUMBER:
                 return new TokenCategory("TK_NUMBER");
-            case IToken.TK_STRING:
+            case TK_STRING:
                 return new TokenCategory("TK_STRING");
-            case IToken.TK_ERROR_KEYWORD:
-            case IToken.TK_KEYWORD:
+            case TK_ERROR_KEYWORD:
+            case TK_KEYWORD:
                 return new TokenCategory("TK_KEYWORD");
-            case IToken.TK_OPERATOR:
+            case TK_OPERATOR:
                 return new TokenCategory("TK_OPERATOR");
-            case IToken.TK_VAR:
+            case TK_VAR:
                 return new TokenCategory("TK_VAR");
-            case IToken.TK_ERROR_LAYOUT:
-            case IToken.TK_LAYOUT:
+            case TK_ERROR_LAYOUT:
+            case TK_LAYOUT:
                 return new TokenCategory("TK_LAYOUT");
             default:
                 logger.debug("Unhandled token kind " + token.getKind());
-            case IToken.TK_UNKNOWN:
-            case IToken.TK_ERROR:
-            case IToken.TK_EOF:
-            case IToken.TK_ERROR_EOF_UNEXPECTED:
-            case IToken.TK_ESCAPE_OPERATOR:
-            case IToken.TK_RESERVED:
-            case IToken.TK_NO_TOKEN_KIND:
+            case TK_UNKNOWN:
+            case TK_ERROR:
+            case TK_EOF:
+            case TK_ERROR_EOF_UNEXPECTED:
+            case TK_ESCAPE_OPERATOR:
+            case TK_RESERVED:
+            case TK_NO_TOKEN_KIND:
                 return null;
         }
     }

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLRParseErrorHandler.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLRParseErrorHandler.java
@@ -1,6 +1,7 @@
 package org.metaborg.spoofax.core.syntax;
 
-import static org.spoofax.jsglr.client.imploder.AbstractTokenizer.*;
+import static org.spoofax.jsglr.client.imploder.AbstractTokenizer.findLeftMostTokenOnSameLine;
+import static org.spoofax.jsglr.client.imploder.AbstractTokenizer.findRightMostTokenOnSameLine;
 import static org.spoofax.jsglr.client.imploder.ImploderAttachment.getTokenizer;
 
 import java.util.ArrayList;
@@ -18,10 +19,7 @@ import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.jsglr.client.MultiBadTokenException;
 import org.spoofax.jsglr.client.ParseTimeoutException;
 import org.spoofax.jsglr.client.RegionRecovery;
-import org.spoofax.jsglr.client.imploder.AbstractTokenizer;
-import org.spoofax.jsglr.client.imploder.IToken;
-import org.spoofax.jsglr.client.imploder.ITokens;
-import org.spoofax.jsglr.client.imploder.Token;
+import org.spoofax.jsglr.client.imploder.*;
 import org.spoofax.jsglr.shared.BadTokenException;
 import org.spoofax.jsglr.shared.TokenExpectedException;
 
@@ -33,8 +31,7 @@ public class JSGLRParseErrorHandler {
         "Region could not be parsed because of subsequent syntax error(s) indicated below";
 
     private final JSGLRI<?> parser;
-    @Nullable
-    private final FileObject resource;
+    @Nullable private final FileObject resource;
     private final boolean hasRecoveryRules;
     private final Collection<IMessage> messages = Lists.newArrayList();
 
@@ -62,20 +59,20 @@ public class JSGLRParseErrorHandler {
      */
 
     public void gatherNonFatalErrors(IStrategoTerm top) {
-        final ITokens tokenizer = getTokenizer(top);
+        final ITokenizer tokenizer = (ITokenizer) getTokenizer(top);
         if(tokenizer != null) {
             for(int i = 0, max = tokenizer.getTokenCount(); i < max; i++) {
                 final IToken token = tokenizer.getTokenAt(i);
                 final String error = token.getError();
                 if(error != null) {
-                    if(Objects.equals(error, ITokens.ERROR_SKIPPED_REGION)) {
+                    if(Objects.equals(error, ITokenizer.ERROR_SKIPPED_REGION)) {
                         i = findRightMostWithSameError(token, null);
                         reportSkippedRegion(token, tokenizer.getTokenAt(i));
-                    } else if(error.startsWith(ITokens.ERROR_WARNING_PREFIX)) {
+                    } else if(error.startsWith(ITokenizer.ERROR_WARNING_PREFIX)) {
                         i = findRightMostWithSameError(token, null);
                         reportWarningAtTokens(token, tokenizer.getTokenAt(i), error);
-                    } else if(error.startsWith(ITokens.ERROR_WATER_PREFIX)) {
-                        i = findRightMostWithSameError(token, ITokens.ERROR_WATER_PREFIX);
+                    } else if(error.startsWith(ITokenizer.ERROR_WATER_PREFIX)) {
+                        i = findRightMostWithSameError(token, ITokenizer.ERROR_WATER_PREFIX);
                         reportErrorAtTokens(token, tokenizer.getTokenAt(i), error);
                     } else {
                         i = findRightMostWithSameError(token, null);
@@ -90,7 +87,7 @@ public class JSGLRParseErrorHandler {
 
     private static int findRightMostWithSameError(IToken token, String prefix) {
         final String expectedError = token.getError();
-        final ITokens tokenizer = token.getTokenizer();
+        final ITokenizer tokenizer = (ITokenizer) token.getTokenizer();
         int i = token.getIndex();
         for(int max = tokenizer.getTokenCount(); i + 1 < max; i++) {
             String error = tokenizer.getTokenAt(i + 1).getError();
@@ -112,7 +109,7 @@ public class JSGLRParseErrorHandler {
 
         if(reportedLine == -1) {
             // Report entire region
-            reportErrorAtTokens(left, right, ITokens.ERROR_SKIPPED_REGION);
+            reportErrorAtTokens(left, right, ITokenizer.ERROR_SKIPPED_REGION);
         } else if(reportedLine - line >= LARGE_REGION_SIZE) {
             // Warn at start of region
             reportErrorAtTokens(findLeftMostTokenOnSameLine(left), findRightMostTokenOnSameLine(left),
@@ -176,7 +173,7 @@ public class JSGLRParseErrorHandler {
         } else {
             IToken token = tokenizer.getTokenAtOffset(exception.getOffset());
             token = findNextNonEmptyToken(token);
-            message = ITokens.ERROR_WATER_PREFIX + ": " + token.toString().trim();
+            message = ITokenizer.ERROR_WATER_PREFIX + ": " + token.toString().trim();
         }
         reportErrorNearOffset(tokenizer, exception.getOffset(), message);
     }
@@ -189,7 +186,7 @@ public class JSGLRParseErrorHandler {
     }
 
     private static IToken findNextNonEmptyToken(IToken token) {
-        final ITokens tokenizer = token.getTokenizer();
+        final ITokenizer tokenizer = (ITokenizer) token.getTokenizer();
         IToken result = null;
         for(int i = token.getIndex(), max = tokenizer.getTokenCount(); i < max; i++) {
             result = tokenizer.getTokenAt(i);

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLRParseErrorHandler.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLRParseErrorHandler.java
@@ -62,7 +62,7 @@ public class JSGLRParseErrorHandler {
         final ITokenizer tokenizer = (ITokenizer) getTokenizer(top);
         if(tokenizer != null) {
             for(int i = 0, max = tokenizer.getTokenCount(); i < max; i++) {
-                final IToken token = tokenizer.getTokenAt(i);
+                final Token token = tokenizer.getTokenAt(i);
                 final String error = token.getError();
                 if(error != null) {
                     if(Objects.equals(error, ITokenizer.ERROR_SKIPPED_REGION)) {
@@ -85,7 +85,7 @@ public class JSGLRParseErrorHandler {
         }
     }
 
-    private static int findRightMostWithSameError(IToken token, String prefix) {
+    private static int findRightMostWithSameError(Token token, String prefix) {
         final String expectedError = token.getError();
         final ITokenizer tokenizer = (ITokenizer) token.getTokenizer();
         int i = token.getIndex();

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLRSourceRegionFactory.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLRSourceRegionFactory.java
@@ -20,7 +20,7 @@ public class JSGLRSourceRegionFactory {
         int rightEndOffset = right.getEndOffset();
 
         // To fix the difference between offset and cursor position
-        if(left.getKind() != IToken.TK_LAYOUT && !isNullable)
+        if(left.getKind() != IToken.Kind.TK_LAYOUT && !isNullable)
             leftStartOffset++;
 
         if(isNullable)


### PR DESCRIPTION
Depends on metaborg/jsglr#79.

Most important changes:
- The `JSGLRCompletionService` and `JSGLRParseErrorHandler` are specific to JSGLR1, and therefore have to cast the `ITokens` object they get from the imploder attachments to `ITokenizer`.
- The refactoring of the token streams heavily simplifies the `CategorizerService`: it no longer has to think about out-of-order tokens or ambiguous tokens, as that is now the full responsibility of the tokenizers.
- Applied the refactoring of token kinds to an enumeration.