### PR TITLE
Let ArchiveBuilder depend directly on JarBuilder

### DIFF
--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/build/main/ArchiveBuilder.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/build/main/ArchiveBuilder.java
@@ -16,6 +16,7 @@ import org.metaborg.spoofax.meta.core.pluto.SpoofaxBuilderFactory;
 import org.metaborg.spoofax.meta.core.pluto.SpoofaxBuilderFactoryFactory;
 import org.metaborg.spoofax.meta.core.pluto.SpoofaxContext;
 import org.metaborg.spoofax.meta.core.pluto.SpoofaxInput;
+import org.metaborg.spoofax.meta.core.pluto.build.main.PackageBuilder.Output;
 import org.metaborg.spoofax.meta.core.pluto.stamp.DirectoryModifiedStamper;
 import org.metaborg.util.resource.FileSelectorUtils;
 import org.metaborg.util.resource.ZipArchiver;
@@ -35,11 +36,14 @@ public class ArchiveBuilder extends SpoofaxBuilder<ArchiveBuilder.Input, OutputT
         public final Iterable<IExportConfig> exports;
         public final LanguageIdentifier languageIdentifier;
 
+        public final BuildRequest<?, Output, ?, ?> packageBuildRequest;
 
-        public Input(SpoofaxContext context, Origin origin, Iterable<IExportConfig> exports,
+
+        public Input(SpoofaxContext context, Origin origin, BuildRequest<?, Output, ?, ?> packageBuildRequest, Iterable<IExportConfig> exports,
             LanguageIdentifier languageIdentifier) {
             super(context);
             this.origin = origin;
+            this.packageBuildRequest = packageBuildRequest;
             this.exports = exports;
             this.languageIdentifier = languageIdentifier;
         }
@@ -75,6 +79,8 @@ public class ArchiveBuilder extends SpoofaxBuilder<ArchiveBuilder.Input, OutputT
 
     @Override protected OutputTransient<File> build(Input input) throws Throwable {
         requireBuild(input.origin);
+        final Output packageBuilderOutput = requireBuild(input.packageBuildRequest);
+        requireBuild(packageBuilderOutput.jarBuilderOrigin);
 
         final ZipArchiver zipArchiver = new ZipArchiver();
         final FileObject root = paths.root();

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/build/main/PackageBuilder.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/pluto/build/main/PackageBuilder.java
@@ -24,9 +24,8 @@ import com.google.common.collect.Lists;
 import build.pluto.builder.BuildRequest;
 import build.pluto.buildjava.JarBuilder;
 import build.pluto.dependency.Origin;
-import build.pluto.output.None;
 
-public class PackageBuilder extends SpoofaxBuilder<PackageBuilder.Input, None> {
+public class PackageBuilder extends SpoofaxBuilder<PackageBuilder.Input, PackageBuilder.Output> {
     public static class Input extends SpoofaxInput {
         private static final long serialVersionUID = -2379365089609792204L;
 
@@ -45,7 +44,34 @@ public class PackageBuilder extends SpoofaxBuilder<PackageBuilder.Input, None> {
         }
     }
 
-    public static SpoofaxBuilderFactory<Input, None, PackageBuilder> factory =
+    public static class Output implements build.pluto.output.Output {
+        private static final long serialVersionUID = -3404709430588259993L;
+
+        public final Origin jarBuilderOrigin;
+
+        public Output(Origin jarBuilderOrigin) {
+            this.jarBuilderOrigin = jarBuilderOrigin;
+        }
+
+        @Override public int hashCode() {
+            return jarBuilderOrigin.hashCode();
+        }
+
+        @Override public boolean equals(Object obj) {
+            if(this == obj)
+                return true;
+            if(obj == null)
+                return false;
+            if(getClass() != obj.getClass())
+                return false;
+            Output other = (Output) obj;
+            if(!jarBuilderOrigin.equals(other.jarBuilderOrigin))
+                return false;
+            return true;
+        }
+    }
+
+    public static SpoofaxBuilderFactory<Input, Output, PackageBuilder> factory =
         SpoofaxBuilderFactoryFactory.of(PackageBuilder.class, Input.class);
 
 
@@ -54,7 +80,7 @@ public class PackageBuilder extends SpoofaxBuilder<PackageBuilder.Input, None> {
     }
 
 
-    public static BuildRequest<Input, None, PackageBuilder, SpoofaxBuilderFactory<Input, None, PackageBuilder>>
+    public static BuildRequest<Input, Output, PackageBuilder, SpoofaxBuilderFactory<Input, Output, PackageBuilder>>
         request(Input input) {
         return new BuildRequest<>(factory, input);
     }
@@ -72,7 +98,7 @@ public class PackageBuilder extends SpoofaxBuilder<PackageBuilder.Input, None> {
         return context.depPath("package.dep");
     }
 
-    @Override protected None build(Input input) throws Throwable {
+    @Override protected Output build(Input input) throws Throwable {
         requireBuild(input.origin);
 
         final File targetMetaborgDir = toFile(paths.targetMetaborgDir());
@@ -97,9 +123,8 @@ public class PackageBuilder extends SpoofaxBuilder<PackageBuilder.Input, None> {
         final File jarFile = FileUtils.getFile(targetMetaborgDir, jarName);
         final File depPath = FileUtils.getFile(context.depDir, jarName + ".dep");
         final Origin origin = jar(jarFile, targetClassesDir, copyPatternOrigin, depPath, targetClassesDir);
-        requireBuild(origin);
 
-        return None.val;
+        return new Output(origin);
     }
 
     public Origin jar(File jarFile, File baseDir, @Nullable Origin origin, @Nullable File depPath, File... paths)


### PR DESCRIPTION
The `ArchiveBuilder` requires the `target/metaborg/stratego.jar` file, which is produces by the `JarBuilder`. `ArchiveBuilder` has an indirect dependency on this task through the `PackageBuilder`, but it seems that this is not enough. This PR make the `ArchiveBuilder` register a direct dependency on the `JarBuilder` task. 
To do so, the `PackageBuilder` returns the origin of the `JarBuilder` task in its output. The `BuildRequest` for the `PackageBuilder` is passed separately to `ArchiveBuilder` so it has a statically typed way of getting the output of the `PackageBuilder` task. This way the `PackageBuilder` is still required (and therefore executed) at the same time as before. But now the `ArchiveBuilder` can receive the `JarBuilder` origin and directly depend on it too. 

N.B. I've remove a superfluous require of the JarBuilder origin in the `PackageBuilder` because that origin is already required unconditionally in the `jar` method. 