### PR TITLE
Adapt Spoofax 2 to changes in Stratego incremental compiler

### DIFF
--- a/org.metaborg.spoofax.meta.core/build.gradle.kts
+++ b/org.metaborg.spoofax.meta.core/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
   api("org.metaborg:org.metaborg.parsetable:$version")
   api("org.metaborg:stratego.compiler.pack:$version")
   api("org.metaborg:stratego.build:$version")
+  api("org.metaborg:stratego.build.spoofax2:$version")
   api("build.pluto:pluto")
   api("build.pluto:build-java")
   api("org.metaborg:pie.runtime")

--- a/org.metaborg.spoofax.meta.core/pom.xml
+++ b/org.metaborg.spoofax.meta.core/pom.xml
@@ -71,7 +71,7 @@
     	</dependency>
 		<dependency>
 			<groupId>org.metaborg</groupId>
-			<artifactId>stratego.build</artifactId>
+			<artifactId>stratego.build.spoofax2</artifactId>
 			<version>${metaborg-version}</version>
 		</dependency>
 		<dependency>

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/SpoofaxExtensionModule.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/SpoofaxExtensionModule.java
@@ -21,7 +21,7 @@ import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
 
 import mb.pie.taskdefs.guice.GuiceTaskDefsModule;
-import mb.stratego.build.strincr.StrIncrModule;
+import mb.stratego.build.spoofax2.StrIncrModule;
 
 /**
  * Module for extending {@link Spoofax}.

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/stratego/primitive/StrategoPieAnalyzePrimitive.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/stratego/primitive/StrategoPieAnalyzePrimitive.java
@@ -44,7 +44,7 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 
 import mb.pie.api.ExecException;
-import mb.pie.api.PieSession;
+import mb.pie.api.MixedSession;
 import mb.pie.api.STask;
 import mb.pie.api.Task;
 import mb.resource.ResourceKey;
@@ -170,8 +170,8 @@ public class StrategoPieAnalyzePrimitive extends ASpoofaxContextPrimitive implem
         final IStrategoList.Builder errors = B.listBuilder();
         final IStrategoList.Builder warnings = B.listBuilder();
         final IStrategoList.Builder notes = B.listBuilder();
-        try(final PieSession pieSession = pieProviderProvider.get().pie().newSession()) {
-            Analysis.Output analysisInformation = pieSession.require(strIncrAnalysisTask);
+        try(final MixedSession session = pieProviderProvider.get().pie().newSession()) {
+            Analysis.Output analysisInformation = session.require(strIncrAnalysisTask);
 
             for(Message<?> message : analysisInformation.messages) {
                 if(message.moduleFilePath.equals(path)) {
@@ -195,6 +195,8 @@ public class StrategoPieAnalyzePrimitive extends ASpoofaxContextPrimitive implem
             }
         } catch(ExecException e) {
             throw new MetaborgException("Incremental Stratego build failed", e);
+        } catch(InterruptedException e) {
+            // Ignore
         }
 
         return B.tuple(B.list(errors), B.list(warnings), B.list(notes));


### PR DESCRIPTION
Adds a dependency to `stratego.build.spoofax2`, and changes to work with newest version of PIE.

Needs to be merged with:
- https://github.com/metaborg/stratego/pull/10
- https://github.com/metaborg/spoofax-eclipse/pull/18
- https://github.com/metaborg/spoofax-deploy/pull/29