### PR TITLE
Errors for non-assoc by storing extra data in parse table

### DIFF
--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLR1I.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLR1I.java
@@ -100,7 +100,7 @@ public class JSGLR1I extends JSGLRI<ParseTable> {
         }
 
         // add non-assoc warnings to messages
-        messages.addAll(addDisambiguationWarnings(ast, resource));
+        messages.addAll(addNonAssocErrorMessages(ast, resource));
 
         if(config.getImploderSetting() == ImploderImplementation.stratego) {
             for(BadTokenException badTokenException : parser.getCollectedErrors()) {
@@ -200,7 +200,7 @@ public class JSGLR1I extends JSGLRI<ParseTable> {
         return parser.getCollectedErrors();
     }
 
-    protected Collection<? extends IMessage> addDisambiguationWarnings(IStrategoTerm ast,
+    protected Collection<? extends IMessage> addNonAssocErrorMessages(IStrategoTerm ast,
         @Nullable FileObject resource) {
         List<IMessage> result = Lists.newArrayList();
 
@@ -249,7 +249,7 @@ public class JSGLR1I extends JSGLRI<ParseTable> {
 
         if(ast != null && !addedMessage) {
             for(IStrategoTerm child : ast.getAllSubterms()) {
-                result.addAll(addDisambiguationWarnings(child, resource));
+                result.addAll(addNonAssocErrorMessages(child, resource));
             }
         }
 

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLR1I.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLR1I.java
@@ -208,8 +208,8 @@ public class JSGLR1I extends JSGLRI<ParseTable> {
 
         // non-associative and non-nested operators should be flagged with warnings
         if(TermUtils.isAppl(ast) && ast.getAllSubterms().length >= 1) {
-            SetMultimap<String, String> nonAssocProductions = parseTable.getNonAssocPriorities();
-            SetMultimap<String, String> nonNestedProductions = parseTable.getNonNestedPriorities();
+            SetMultimap<String, String> nonAssocProductions = parseTable.getNonAssocProductions();
+            SetMultimap<String, String> nonNestedProductions = parseTable.getNonNestedProductions();
 
             String sortConsParent =
                 ImploderAttachment.getSort(ast) + "." + ((IStrategoAppl) ast).getConstructor().getName();
@@ -226,7 +226,7 @@ public class JSGLR1I extends JSGLRI<ParseTable> {
                     && nonAssocProductions.containsEntry(sortConsParent, sortConsChild)) {
                     ISourceRegion region = JSGLRSourceRegionFactory.fromTokens(ImploderAttachment.getLeftToken(ast),
                         ImploderAttachment.getRightToken(ast));
-                    result.add(MessageFactory.newParseWarning(resource, region, "Operator is non-associative", null));
+                    result.add(MessageFactory.newParseError(resource, region, "Operator is non-associative", null));
                     addedMessage = true;
                 }
             }
@@ -241,7 +241,7 @@ public class JSGLR1I extends JSGLRI<ParseTable> {
                     && nonNestedProductions.containsEntry(sortConsParent, sortConsChild)) {
                     ISourceRegion region = JSGLRSourceRegionFactory.fromTokens(ImploderAttachment.getLeftToken(ast),
                         ImploderAttachment.getRightToken(ast));
-                    result.add(MessageFactory.newParseWarning(resource, region, "Operator is non-nested", null));
+                    result.add(MessageFactory.newParseError(resource, region, "Operator is non-nested", null));
                     addedMessage = true;
                 }
             }

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLR2I.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLR2I.java
@@ -112,9 +112,6 @@ public class JSGLR2I extends JSGLRI<IParseTable> {
         boolean isAmbiguous = result.isSuccess() && ((JSGLR2Success<IStrategoTerm>) result).isAmbiguous();
         final Collection<IMessage> messages = mapMessages(resource, result.messages);
 
-        // add non-assoc warnings to messages
-        messages.addAll(addDisambiguationWarnings(ast, resource));
-
         final long duration = timer.stop();
 
         final boolean hasAst = ast != null;
@@ -152,14 +149,6 @@ public class JSGLR2I extends JSGLRI<IParseTable> {
 
     @Override public Set<BadTokenException> getCollectedErrors() {
         return Collections.emptySet();
-    }
-
-    @Override public SetMultimap<String, String> getNonAssocPriorities() {
-        return ((ParseTable) parseTable).normalizedGrammar().getNonAssocProductions();
-    }
-
-    @Override public SetMultimap<String, String> getNonNestedPriorities() {
-        return ((ParseTable) parseTable).normalizedGrammar().getNonNestedProductions();
     }
 
 }

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLR2I.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLR2I.java
@@ -155,11 +155,11 @@ public class JSGLR2I extends JSGLRI<IParseTable> {
     }
 
     @Override public SetMultimap<String, String> getNonAssocPriorities() {
-        return ((ParseTable) parseTable).normalizedGrammar().getNonAssocPriorities();
+        return ((ParseTable) parseTable).normalizedGrammar().getNonAssocProductions();
     }
 
     @Override public SetMultimap<String, String> getNonNestedPriorities() {
-        return ((ParseTable) parseTable).normalizedGrammar().getNonNestedPriorities();
+        return ((ParseTable) parseTable).normalizedGrammar().getNonNestedProductions();
     }
 
 }

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLRI.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/syntax/JSGLRI.java
@@ -1,34 +1,22 @@
 package org.metaborg.spoofax.core.syntax;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.List;
 import java.util.Set;
 
 import javax.annotation.Nullable;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.SetMultimap;
 import org.apache.commons.vfs2.FileObject;
 import org.metaborg.core.language.ILanguageImpl;
-import org.metaborg.core.messages.IMessage;
-import org.metaborg.core.messages.MessageFactory;
-import org.metaborg.core.source.ISourceRegion;
 import org.metaborg.spoofax.core.unit.ParseContrib;
-import org.spoofax.interpreter.terms.IStrategoAppl;
-import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermFactory;
-import org.spoofax.jsglr.client.ParseTable;
-import org.spoofax.jsglr.client.imploder.ImploderAttachment;
 import org.spoofax.jsglr.shared.BadTokenException;
-import org.spoofax.terms.util.TermUtils;
 
 abstract public class JSGLRI<PT> {
     protected final IParserConfig config;
     protected final ITermFactory termFactory;
     protected final ILanguageImpl language;
     protected final ILanguageImpl dialect;
-    
+
     protected PT parseTable;
 
     public JSGLRI(IParserConfig config, ITermFactory termFactory, ILanguageImpl language, ILanguageImpl dialect) {
@@ -69,61 +57,4 @@ abstract public class JSGLRI<PT> {
         return dialect;
     }
 
-    abstract public SetMultimap<String, String> getNonAssocPriorities();
-
-    abstract public SetMultimap<String, String> getNonNestedPriorities();
-
-    protected Collection<? extends IMessage> addDisambiguationWarnings(IStrategoTerm ast,
-        @Nullable FileObject resource) {
-        List<IMessage> result = Lists.newArrayList();
-
-        boolean addedMessage = false;
-
-        // non-associative and non-nested operators should be flagged with warnings
-        if(TermUtils.isAppl(ast) && ast.getAllSubterms().length >= 1) {
-            String sortConsParent =
-                ImploderAttachment.getSort(ast) + "." + ((IStrategoAppl) ast).getConstructor().getName();
-
-            IStrategoTerm firstChild = ast.getSubterm(0);
-            IStrategoTerm lastChild = ast.getSubterm(ast.getSubtermCount() - 1);
-
-            if(TermUtils.isAppl(firstChild)) {
-                IStrategoAppl leftMostChild = (IStrategoAppl) firstChild;
-                @Nullable ImploderAttachment leftMostChildAttachment = ImploderAttachment.get(leftMostChild);
-                String sortConsChild = ImploderAttachment.getSort(ast) + "." + leftMostChild.getConstructor().getName();
-                if(leftMostChildAttachment != null && !leftMostChildAttachment.isBracket()
-                    && parseTable instanceof ParseTable
-                    && getNonAssocPriorities().containsEntry(sortConsParent, sortConsChild)) {
-                    ISourceRegion region = JSGLRSourceRegionFactory.fromTokens(ImploderAttachment.getLeftToken(ast),
-                        ImploderAttachment.getRightToken(ast));
-                    result.add(MessageFactory.newParseWarning(resource, region, "Operator is non-associative", null));
-                    addedMessage = true;
-                }
-            }
-
-            if(TermUtils.isAppl(lastChild)) {
-                IStrategoAppl rightMostChild = (IStrategoAppl) lastChild;
-                @Nullable ImploderAttachment rightMostChildAttachment = ImploderAttachment.get(rightMostChild);
-                String sortConsChild =
-                    ImploderAttachment.getSort(ast) + "." + rightMostChild.getConstructor().getName();
-                if(rightMostChildAttachment != null && !rightMostChildAttachment.isBracket()
-                    && parseTable instanceof ParseTable
-                    && getNonNestedPriorities().containsEntry(sortConsParent, sortConsChild)) {
-                    ISourceRegion region = JSGLRSourceRegionFactory.fromTokens(ImploderAttachment.getLeftToken(ast),
-                        ImploderAttachment.getRightToken(ast));
-                    result.add(MessageFactory.newParseWarning(resource, region, "Operator is non-nested", null));
-                    addedMessage = true;
-                }
-            }
-        }
-
-        if(ast != null && !addedMessage) {
-            for(IStrategoTerm child : ast.getAllSubterms()) {
-                result.addAll(addDisambiguationWarnings(child, resource));
-            }
-        }
-
-        return result;
-    }
-    
 }


### PR DESCRIPTION
To be merged together with metaborg/jsglr#86 and metaborg/sdf#50. Recommended order of reading: SDF, JSGLR, Spoofax.

The method `JSGLRI.addDisambiguationWarnings` has been moved/renamed to `JGSLR1I.addNonAssocErrorMessages`. Because of this and the fact that JSGLR2 now generates its own error messages, `JSGLRI` no longer needs the abstract `getNon{Assoc,Nested}Productions` methods.

Finally, JSGLR1 now also generates an error instead of a warning (see JSGLR1I.java:{[229](https://github.com/metaborg/spoofax/compare/master...mpsijm:non-assoc-warnings?expand=1#diff-986b82ec1d8965060e01d44ca64d44a5R229),[244](https://github.com/metaborg/spoofax/compare/master...mpsijm:non-assoc-warnings?expand=1#diff-986b82ec1d8965060e01d44ca64d44a5R244)}).