### PR TITLE
Convert contentTerm only to string if actually writing to output file

### DIFF
--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/transform/StrategoTransformer.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/transform/StrategoTransformer.java
@@ -239,10 +239,10 @@ public class StrategoTransformer implements IStrategoTransformer {
             throw new MetaborgException("First term of result tuple {} is not a string, cannot write output file");
         } else {
             final String resourceString = TermUtils.toJavaString(resourceTerm);
-            final String resultContents = common.toString(contentTerm);
             // writing to output file is allowed
             FileObject output;
             if(!config.dryRun()) {
+                final String resultContents = common.toString(contentTerm);
                 output = resourceService.resolve(location, resourceString);
                 try(OutputStream stream = output.getContent().getOutputStream()) {
                     IOUtils.write(resultContents, stream, Charset.defaultCharset());


### PR DESCRIPTION
In case of a dry run, the conversion to string is only wasting CPU cycles.
Discovered while looking at profiling results. Cost was significant, about 2% (or about 700 ms) on a single medium sized run.