### PR TITLE
Log ignored exception

### DIFF
--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/transform/StrategoTransformer.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/transform/StrategoTransformer.java
@@ -200,6 +200,7 @@ public class StrategoTransformer implements IStrategoTransformer {
                     outputs = Collections.emptyList();
                 }
             } catch(MetaborgException ex) {
+                logger.error("Failed to output result", ex);
                 resultTerm = null;
                 outputs = Collections.emptyList();
             }


### PR DESCRIPTION
Transformation result could be invalid and ignored without any reason showing up in logs anywhere.
There appears to be only one situation where this would be the case, which is when multiple output files are returned and one of the resource subterms is not a string.