### PR TITLE
Incremental typechecking configuration

### DIFF
--- a/org.metaborg.core/src/main/java/org/metaborg/core/config/ILanguageComponentConfig.java
+++ b/org.metaborg.core/src/main/java/org/metaborg/core/config/ILanguageComponentConfig.java
@@ -7,7 +7,7 @@ import org.metaborg.core.language.LanguageIdentifier;
 
 /**
  * Configuration of a language component at runtime.
- * 
+ *
  * To create a new instance of this interface, use an {@link ILanguageComponentConfigBuilder} interface.
  */
 public interface ILanguageComponentConfig extends IProjectConfig {
@@ -31,28 +31,28 @@ public interface ILanguageComponentConfig extends IProjectConfig {
      * @return The language contributions.
      */
     Collection<LanguageContributionIdentifier> langContribs();
-    
+
     /**
      * Gets the languages for while files are generated.
      *
      * @return The languages for while files are generated.
      */
     Collection<IGenerateConfig> generates();
-    
+
     /**
      * Gets whether the project depends on SDF or not.
      *
      * @return true if SDF is enabled and false otherwise.
      */
-    Boolean sdfEnabled();   
-    
+    Boolean sdfEnabled();
+
     /**
      * Gets the (relative) path to the parse table.
      *
      * @return path to the parse table.
      */
-    String parseTable();    
-    
+    String parseTable();
+
     /**
      * Gets the (relative) path to the completions parse table.
      *
@@ -66,14 +66,14 @@ public interface ILanguageComponentConfig extends IProjectConfig {
      * @return sdf2table version to use.
      */
     Sdf2tableVersion sdf2tableVersion();
-    
+
     /**
      * Gets whether to check for missing priorities in expression grammars or not.
      *
      * @return true if checking for priorities and false otherwise.
      */
     Boolean checkPriorities();
-    
+
     /**
      * Gets whether to check for harmful overlap in productions that cause inherent ambiguities.
      *
@@ -94,13 +94,13 @@ public interface ILanguageComponentConfig extends IProjectConfig {
      * @return the logging scope.
      */
     JSGLR2Logging jsglr2Logging();
-    
+
     /**
      * Return Statix configuration for this language component.
-     * 
+     *
      * Specific to Spoofax.
      */
-    boolean statixConcurrentComponent();
+    StatixSolverMode statixSolverMode();
 
     /**
      * Gets the file exports.
@@ -109,5 +109,5 @@ public interface ILanguageComponentConfig extends IProjectConfig {
      */
     Collection<IExportConfig> exports();
 
-    
+
 }

--- a/org.metaborg.core/src/main/java/org/metaborg/core/config/ILanguageComponentConfigBuilder.java
+++ b/org.metaborg.core/src/main/java/org/metaborg/core/config/ILanguageComponentConfigBuilder.java
@@ -12,7 +12,7 @@ import org.metaborg.core.language.LanguageIdentifier;
 public interface ILanguageComponentConfigBuilder {
     /**
      * Builds the configuration.
-     * 
+     *
      * @return The built configuration.
      */
     ILanguageComponentConfig build(@Nullable FileObject rootFolder) throws IllegalStateException;
@@ -106,7 +106,7 @@ public interface ILanguageComponentConfigBuilder {
      * @return This builder.
      */
     ILanguageComponentConfigBuilder withSdfTable(String parseTable);
-    
+
     /**
      * Sets whether SDF is enabled in the project
      *
@@ -115,9 +115,9 @@ public interface ILanguageComponentConfigBuilder {
      * @return This builder.
      */
     ILanguageComponentConfigBuilder withSdfEnabled(Boolean sdfEnabled);
-    
+
     ILanguageComponentConfigBuilder withCheckOverlap(Boolean checkOverlap);
-    
+
     /**
      * Sets the completion parse table (relative) path.
      *
@@ -135,7 +135,7 @@ public interface ILanguageComponentConfigBuilder {
      * @return This builder.
      */
     ILanguageComponentConfigBuilder withSdf2tableVersion(Sdf2tableVersion sdf2tableVersion);
-    
+
     /**
      * Sets the JSGLR parser version.
      *
@@ -155,13 +155,13 @@ public interface ILanguageComponentConfigBuilder {
     ILanguageComponentConfigBuilder withJSGLR2Logging(JSGLR2Logging jsglr2Logging);
 
     /**
-     * Set whether concurrent solver should be used.
-     * 
-     * @param concurrent
-     *            True to enable, false to disable.
+     * Set which solver configuration should be used.
+     *
+     * @param mode
+     *            The Statix solver mode
      * @return This builder.
      */
-    ILanguageComponentConfigBuilder withStatixConcurrent(Boolean concurrent);
+    ILanguageComponentConfigBuilder withStatixConcurrent(StatixSolverMode mode);
 
     /**
      * Adds language contributions.

--- a/org.metaborg.core/src/main/java/org/metaborg/core/config/LanguageComponentConfig.java
+++ b/org.metaborg.core/src/main/java/org/metaborg/core/config/LanguageComponentConfig.java
@@ -41,6 +41,7 @@ public class LanguageComponentConfig extends AConfig implements ILanguageCompone
     private static final String PROP_SDF_JSGLR2_LOGGING = PROP_SDF + ".jsglr2-logging";
 
     private static final String PROP_STATIX = PROP_LANGUAGE + ".statix";
+    private static final String PROP_STATIX_CONCURRENT = PROP_STATIX + ".concurrent";
     private static final String PROP_STATIX_MODE = PROP_STATIX + ".mode";
 
     private final ProjectConfig projectConfig;
@@ -291,6 +292,10 @@ public class LanguageComponentConfig extends AConfig implements ILanguageCompone
     @Override public StatixSolverMode statixSolverMode() {
         String value = this.config.getString(PROP_STATIX_MODE);
         if(value == null) {
+            if(this.config.getBoolean(PROP_STATIX_CONCURRENT, false)) {
+                logger.warn("Config option {} is deprecated. Use {}: concurrent instead.", PROP_STATIX_CONCURRENT, PROP_STATIX_MODE);
+                return StatixSolverMode.concurrent;
+            }
             return StatixSolverMode.traditional;
         }
         if(value.equals("incremental-scopegraph-diff")) {

--- a/org.metaborg.core/src/main/java/org/metaborg/core/config/LanguageComponentConfig.java
+++ b/org.metaborg.core/src/main/java/org/metaborg/core/config/LanguageComponentConfig.java
@@ -41,7 +41,7 @@ public class LanguageComponentConfig extends AConfig implements ILanguageCompone
     private static final String PROP_SDF_JSGLR2_LOGGING = PROP_SDF + ".jsglr2-logging";
 
     private static final String PROP_STATIX = PROP_LANGUAGE + ".statix";
-    private static final String PROP_STATIX_CONCURRENT = PROP_STATIX + ".concurrent";
+    private static final String PROP_STATIX_MODE = PROP_STATIX + ".mode";
 
     private final ProjectConfig projectConfig;
 
@@ -57,7 +57,7 @@ public class LanguageComponentConfig extends AConfig implements ILanguageCompone
             @Nullable String parseTable, @Nullable String completionParseTable,
             @Nullable Sdf2tableVersion sdf2tableVersion, @Nullable Boolean checkOverlap,
             @Nullable Boolean checkPriorities, @Nullable Boolean dataDependent, @Nullable JSGLRVersion jsglrVersion,
-            @Nullable JSGLR2Logging jsglr2Logging, @Nullable Boolean statixConcurrent,
+            @Nullable JSGLR2Logging jsglr2Logging, @Nullable StatixSolverMode statixMode,
             @Nullable Collection<LanguageContributionIdentifier> langContribs,
             @Nullable Collection<IGenerateConfig> generates, @Nullable Collection<IExportConfig> exports) {
         super(config);
@@ -87,8 +87,8 @@ public class LanguageComponentConfig extends AConfig implements ILanguageCompone
         if(jsglr2Logging != null) {
             config.setProperty(PROP_SDF_JSGLR2_LOGGING, jsglr2Logging);
         }
-        if(statixConcurrent != null) {
-            config.setProperty(PROP_STATIX_CONCURRENT, statixConcurrent);
+        if(statixMode != null) {
+            config.setProperty(PROP_STATIX_MODE, statixMode);
         }
         if(name != null) {
             config.setProperty(PROP_NAME, name);
@@ -288,8 +288,15 @@ public class LanguageComponentConfig extends AConfig implements ILanguageCompone
         return value != null ? JSGLR2Logging.valueOf(value) : JSGLR2Logging.none;
     }
 
-    @Override public boolean statixConcurrentComponent() {
-        return config.getBoolean(PROP_STATIX_CONCURRENT, false);
+    @Override public StatixSolverMode statixSolverMode() {
+        String value = this.config.getString(PROP_STATIX_MODE);
+        if(value == null) {
+            return StatixSolverMode.traditional;
+        }
+        if(value.equals("incremental-scopegraph-diff")) {
+            return StatixSolverMode.incrementalScopeGraphDiff;
+        }
+        return StatixSolverMode.valueOf(value);
     }
 
 }

--- a/org.metaborg.core/src/main/java/org/metaborg/core/config/LanguageComponentConfigBuilder.java
+++ b/org.metaborg.core/src/main/java/org/metaborg/core/config/LanguageComponentConfigBuilder.java
@@ -35,7 +35,7 @@ public class LanguageComponentConfigBuilder extends AConfigBuilder implements IL
     protected @Nullable Boolean dataDependent;
     protected @Nullable JSGLRVersion jsglrVersion;
     protected @Nullable JSGLR2Logging jsglr2Logging;
-    protected @Nullable Boolean statixConcurrent;
+    protected @Nullable StatixSolverMode statixMode;
 
     @Inject public LanguageComponentConfigBuilder(AConfigurationReaderWriter configReaderWriter) {
         super(configReaderWriter);
@@ -50,7 +50,7 @@ public class LanguageComponentConfigBuilder extends AConfigBuilder implements IL
         ProjectConfig projectConfig = projectConfigBuilder.build(configuration);
         final LanguageComponentConfig config = new LanguageComponentConfig(configuration, projectConfig, identifier,
             name, sdfEnabled, parseTable, completionsParseTable, sdf2tableVersion, checkOverlap, checkPriorities,
-            dataDependent, jsglrVersion, jsglr2Logging, statixConcurrent, langContribs, generates, exports);
+            dataDependent, jsglrVersion, jsglr2Logging, statixMode, langContribs, generates, exports);
         return config;
     }
 
@@ -70,7 +70,7 @@ public class LanguageComponentConfigBuilder extends AConfigBuilder implements IL
         jsglrVersion = null;
         jsglr2Logging = null;
         sdfEnabled = null;
-        statixConcurrent = null;
+        statixMode = null;
         return this;
     }
 
@@ -89,7 +89,7 @@ public class LanguageComponentConfigBuilder extends AConfigBuilder implements IL
             withSdf2tableVersion(config.sdf2tableVersion());
             withJSGLRVersion(config.jsglrVersion());
             withJSGLR2Logging(config.jsglr2Logging());
-            withStatixConcurrent(config.statixConcurrentComponent());
+            withStatixConcurrent(config.statixSolverMode());
             withCheckOverlap(config.checkOverlap());
             withCheckPriorities(config.checkPriorities());
             withSdfEnabled(config.sdfEnabled());
@@ -187,8 +187,8 @@ public class LanguageComponentConfigBuilder extends AConfigBuilder implements IL
         return this;
     }
 
-    @Override public ILanguageComponentConfigBuilder withStatixConcurrent(Boolean enable) {
-        this.statixConcurrent = enable;
+    @Override public ILanguageComponentConfigBuilder withStatixConcurrent(StatixSolverMode mode) {
+        this.statixMode = mode;
         return this;
     }
 

--- a/org.metaborg.core/src/main/java/org/metaborg/core/config/StatixSolverMode.java
+++ b/org.metaborg.core/src/main/java/org/metaborg/core/config/StatixSolverMode.java
@@ -1,0 +1,5 @@
+package org.metaborg.core.config;
+
+public enum StatixSolverMode {
+    traditional, concurrent, incrementalScopeGraphDiff
+}

--- a/org.metaborg.meta.core/src/main/java/org/metaborg/meta/core/config/LanguageSpecConfig.java
+++ b/org.metaborg.meta.core/src/main/java/org/metaborg/meta/core/config/LanguageSpecConfig.java
@@ -31,12 +31,12 @@ public class LanguageSpecConfig extends LanguageComponentConfig implements ILang
         @Nullable LanguageIdentifier id, @Nullable String name, @Nullable Boolean sdfEnabled,
         @Nullable Sdf2tableVersion sdf2tableVersion, @Nullable Boolean checkOverlap, @Nullable Boolean checkPriorities,
         @Nullable Boolean dataDependent, @Nullable String parseTable, @Nullable String completionsParseTable,
-        @Nullable JSGLRVersion jsglrVersion, @Nullable JSGLR2Logging jsglr2Logging, @Nullable Boolean statixConcurrent,
+        @Nullable JSGLRVersion jsglrVersion, @Nullable JSGLR2Logging jsglr2Logging, @Nullable StatixSolverMode statixMode,
         @Nullable Collection<LanguageContributionIdentifier> langContribs,
         @Nullable Collection<IGenerateConfig> generates, @Nullable Collection<IExportConfig> exports,
         @Nullable Collection<String> pardonedLanguages, @Nullable Boolean useBuildSystemSpec) {
         super(config, projectConfig, id, name, sdfEnabled, parseTable, completionsParseTable, sdf2tableVersion,
-            checkOverlap, checkPriorities, dataDependent, jsglrVersion, jsglr2Logging, statixConcurrent, langContribs,
+            checkOverlap, checkPriorities, dataDependent, jsglrVersion, jsglr2Logging, statixMode, langContribs,
             generates, exports);
 
         if(pardonedLanguages != null) {

--- a/org.metaborg.meta.core/src/main/java/org/metaborg/meta/core/config/LanguageSpecConfigBuilder.java
+++ b/org.metaborg.meta.core/src/main/java/org/metaborg/meta/core/config/LanguageSpecConfigBuilder.java
@@ -39,7 +39,7 @@ public class LanguageSpecConfigBuilder extends LanguageComponentConfigBuilder im
         final LanguageSpecConfig config =
             new LanguageSpecConfig(configuration, projectConfig, identifier, name, sdfEnabled, sdf2tableVersion,
                 checkOverlap, checkPriorities, dataDependent, parseTable, completionsParseTable, jsglrVersion,
-                jsglr2Logging, statixConcurrent, langContribs, generates, exports, pardonedLanguages, useBuildSystemSpec);
+                jsglr2Logging, statixMode, langContribs, generates, exports, pardonedLanguages, useBuildSystemSpec);
         return config;
     }
 

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/SpoofaxModule.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/SpoofaxModule.java
@@ -137,6 +137,7 @@ import org.metaborg.spoofax.core.stratego.primitive.nabl2.SG_is_debug_resolution
 import org.metaborg.spoofax.core.stratego.primitive.renaming.RenamingLibrary;
 import org.metaborg.spoofax.core.stratego.primitive.statix.STX_is_concurrent_enabled;
 import org.metaborg.spoofax.core.stratego.primitive.statix.STX_project_config;
+import org.metaborg.spoofax.core.stratego.primitive.statix.STX_solver_mode;
 import org.metaborg.spoofax.core.stratego.primitive.statix.StatixLibrary;
 import org.metaborg.spoofax.core.stratego.primitive.nabl2.NaBL2Library;
 import org.metaborg.spoofax.core.stratego.strategies.ParseFileStrategy;
@@ -499,6 +500,7 @@ public class SpoofaxModule extends MetaborgModule {
         // libspoofax
         bindPrimitive(statixLibrary, STX_is_concurrent_enabled.class);
         bindPrimitive(statixLibrary, STX_project_config.class);
+        bindPrimitive(statixLibrary, STX_solver_mode.class);
         // statix.solver
         bindPrimitive(statixLibrary, STX_analysis_has_errors.class);
         bindPrimitive(statixLibrary, STX_compare_patterns.class);

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/config/language/StatixProjectConfigReaderWriter.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/config/language/StatixProjectConfigReaderWriter.java
@@ -1,31 +1,51 @@
 package org.metaborg.spoofax.core.config.language;
 
 import java.util.Collection;
-import java.util.Set;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.commons.configuration2.HierarchicalConfiguration;
 import org.apache.commons.configuration2.tree.ImmutableNode;
+import org.metaborg.util.log.ILogger;
+import org.metaborg.util.log.LoggerUtils;
 
 import mb.statix.spoofax.IStatixProjectConfig;
+import mb.statix.spoofax.SolverMode;
 import mb.statix.spoofax.StatixProjectConfig;
 
 public class StatixProjectConfigReaderWriter {
 
+    private static final ILogger logger = LoggerUtils.logger(StatixProjectConfigReaderWriter.class);
+
     private static final String PROP_CONCURRENT = "concurrent";
+    private static final String PROP_MODES = "modes";
     private static final String PROP_MESSAGE_TRACE_LENGTH = "message-trace-length";
     private static final String PROP_MESSAGE_TERM_DEPTH = "message-term-depth";
 
     public static IStatixProjectConfig read(HierarchicalConfiguration<ImmutableNode> config) {
-        Collection<String> parallelLanguages = config.getList(String.class, PROP_CONCURRENT, null);
+        Collection<String> parallelLanguages = config.getList(String.class, PROP_CONCURRENT, Collections.emptyList());
+        Map<String, SolverMode> modes = new HashMap<>();
+        if(!parallelLanguages.isEmpty()) {
+            logger.warn("Option runtime.statix.concurrent is deprecated. Use runtime.statix.modes.<lang>.<mode> instead.");
+        }
+        parallelLanguages.forEach(languageName -> modes.put(languageName, SolverMode.CONCURRENT));
+        config.getKeys(PROP_MODES).forEachRemaining(modeKey -> {
+            String languageName = modeKey.substring(PROP_MODES.length() + 1);
+            SolverMode mode = SolverMode.valueOf(config.getString(modeKey).toUpperCase());
+            modes.put(languageName, mode);
+        });
         Integer messageStacktraceLength = config.getInteger(PROP_MESSAGE_TRACE_LENGTH, null);
         Integer messageTermDepth = config.getInteger(PROP_MESSAGE_TERM_DEPTH, null);
-        return new StatixProjectConfig(parallelLanguages, messageStacktraceLength, messageTermDepth);
+        return new StatixProjectConfig(modes, messageStacktraceLength, messageTermDepth);
     }
 
     public static void write(IStatixProjectConfig statixConfig, HierarchicalConfiguration<ImmutableNode> config) {
-        final Set<String> parallelLanguages = statixConfig.parallelLanguages(null);
-        if(parallelLanguages != null) {
-            config.setProperty(PROP_CONCURRENT, parallelLanguages);
+        final Map<String, SolverMode> languageModes = statixConfig.languageModes(null);
+        if(languageModes != null) {
+            for(String languageName : languageModes.keySet()) {
+                config.setProperty(String.format("%s.%s", PROP_MODES, languageName), languageModes.get(languageName));
+            }
         }
         final Integer messageStacktraceLength = statixConfig.messageTraceLength(null);
         if(messageStacktraceLength != null) {

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/config/language/StatixProjectConfigReaderWriter.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/config/language/StatixProjectConfigReaderWriter.java
@@ -32,7 +32,7 @@ public class StatixProjectConfigReaderWriter {
         parallelLanguages.forEach(languageName -> modes.put(languageName, SolverMode.CONCURRENT));
         config.getKeys(PROP_MODES).forEachRemaining(modeKey -> {
             String languageName = modeKey.substring(PROP_MODES.length() + 1);
-            SolverMode mode = SolverMode.valueOf(config.getString(modeKey).toUpperCase());
+            SolverMode mode = SolverMode.valueOf(config.getString(modeKey).toUpperCase().replace('-', '_'));
             modes.put(languageName, mode);
         });
         Integer messageStacktraceLength = config.getInteger(PROP_MESSAGE_TRACE_LENGTH, null);

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/primitive/statix/STX_is_concurrent_enabled.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/primitive/statix/STX_is_concurrent_enabled.java
@@ -2,6 +2,7 @@ package org.metaborg.spoofax.core.stratego.primitive.statix;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Map;
 
 import org.metaborg.core.MetaborgException;
 import org.metaborg.core.context.IContext;
@@ -14,6 +15,8 @@ import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermFactory;
 
 import com.google.inject.Inject;
+
+import mb.statix.spoofax.SolverMode;
 
 public class STX_is_concurrent_enabled extends ASpoofaxContextPrimitive {
 
@@ -29,9 +32,9 @@ public class STX_is_concurrent_enabled extends ASpoofaxContextPrimitive {
             IContext context) throws MetaborgException, IOException {
         ISpoofaxProjectConfig config = projectConfigService.get(context.project());
         if(config != null) {
-            boolean concurrentInProject = config.statixConfig().parallelLanguages(Collections.emptySet())
-                    .contains(context.language().belongsTo().name());
-            if(concurrentInProject) {
+            String languageName = context.language().belongsTo().name();
+            Map<String, SolverMode> modes = config.statixConfig().languageModes(Collections.emptyMap());
+            if(modes.containsKey(languageName) && modes.get(languageName) != SolverMode.TRADITIONAL) {
                 return current;
             }
         }

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/primitive/statix/STX_is_concurrent_enabled.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/primitive/statix/STX_is_concurrent_enabled.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.metaborg.core.MetaborgException;
+import org.metaborg.core.config.StatixSolverMode;
 import org.metaborg.core.context.IContext;
 import org.metaborg.spoofax.core.analysis.AnalysisFacet;
 import org.metaborg.spoofax.core.config.ISpoofaxProjectConfig;
@@ -39,7 +40,7 @@ public class STX_is_concurrent_enabled extends ASpoofaxContextPrimitive {
             }
         }
         boolean concurrentInLanguage = context.language().components().stream()
-                .anyMatch(lc -> lc.hasFacet(AnalysisFacet.class) && lc.config().statixConcurrentComponent());
+                .anyMatch(lc -> lc.hasFacet(AnalysisFacet.class) && lc.config().statixSolverMode() != StatixSolverMode.traditional);
         if(concurrentInLanguage) {
             return current;
         }

--- a/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/primitive/statix/STX_solver_mode.java
+++ b/org.metaborg.spoofax.core/src/main/java/org/metaborg/spoofax/core/stratego/primitive/statix/STX_solver_mode.java
@@ -1,0 +1,64 @@
+package org.metaborg.spoofax.core.stratego.primitive.statix;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import org.metaborg.core.MetaborgException;
+import org.metaborg.core.config.StatixSolverMode;
+import org.metaborg.core.context.IContext;
+import org.metaborg.spoofax.core.analysis.AnalysisFacet;
+import org.metaborg.spoofax.core.config.ISpoofaxProjectConfig;
+import org.metaborg.spoofax.core.config.ISpoofaxProjectConfigService;
+import org.metaborg.spoofax.core.stratego.primitive.generic.ASpoofaxContextPrimitive;
+import org.spoofax.interpreter.stratego.Strategy;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.ITermFactory;
+
+import com.google.inject.Inject;
+
+import mb.flowspec.terms.B;
+import mb.statix.spoofax.SolverMode;
+
+public class STX_solver_mode extends ASpoofaxContextPrimitive {
+
+    final ISpoofaxProjectConfigService projectConfigService;
+
+    @Inject public STX_solver_mode(ISpoofaxProjectConfigService projectConfigService) {
+        super(STX_solver_mode.class.getSimpleName(), 0, 0);
+        this.projectConfigService = projectConfigService;
+    }
+
+    @Override protected IStrategoTerm call(IStrategoTerm current, Strategy[] svars, IStrategoTerm[] tvars,
+            ITermFactory factory, IContext context) throws MetaborgException, IOException {
+        ISpoofaxProjectConfig config = projectConfigService.get(context.project());
+        if(config != null) {
+            String languageName = context.language().belongsTo().name();
+            Map<String, SolverMode> modes = config.statixConfig().languageModes(Collections.emptyMap());
+            if(modes.containsKey(languageName)) {
+                return B.blob(modes.get(languageName));
+            }
+        }
+        // @formatter:off
+        return B.blob(getSolverMode(context.language().components().stream()
+                .filter(lc -> lc.hasFacet(AnalysisFacet.class) && lc.config().statixSolverMode() != null)
+                .findAny()
+                .map(lc -> lc.config().statixSolverMode())
+                .orElse(StatixSolverMode.traditional)));
+        // @formatter:on
+    }
+
+    private SolverMode getSolverMode(StatixSolverMode mode) throws MetaborgException {
+        switch(mode) {
+            case traditional:
+                return SolverMode.TRADITIONAL;
+            case concurrent:
+                return SolverMode.CONCURRENT;
+            case incrementalScopeGraphDiff:
+                return SolverMode.INCREMENTAL_SCOPEGRAPH_DIFF;
+            default:
+                throw new MetaborgException("Cannot get solver mode for configuration option " + mode);
+        }
+    }
+
+}

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/config/SpoofaxLanguageSpecConfig.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/config/SpoofaxLanguageSpecConfig.java
@@ -13,6 +13,7 @@ import org.metaborg.core.config.IGenerateConfig;
 import org.metaborg.core.config.JSGLR2Logging;
 import org.metaborg.core.config.JSGLRVersion;
 import org.metaborg.core.config.Sdf2tableVersion;
+import org.metaborg.core.config.StatixSolverMode;
 import org.metaborg.core.language.LanguageContributionIdentifier;
 import org.metaborg.core.language.LanguageIdentifier;
 import org.metaborg.core.messages.IMessage;
@@ -82,7 +83,7 @@ public class SpoofaxLanguageSpecConfig extends LanguageSpecConfig implements ISp
             @Nullable SdfVersion sdfVersion, @Nullable Boolean sdfEnabled, @Nullable Sdf2tableVersion sdf2tableVersion,
             @Nullable Boolean checkOverlap, @Nullable Boolean checkPriorities, @Nullable Boolean dataDependent,
             @Nullable String parseTable, @Nullable String completionsParseTable, @Nullable JSGLRVersion jsglrVersion,
-            @Nullable JSGLR2Logging jsglr2Logging, Boolean statixConcurrent, @Nullable String sdfMainFile,
+            @Nullable JSGLR2Logging jsglr2Logging, @Nullable StatixSolverMode statixMode, @Nullable String sdfMainFile,
             @Nullable PlaceholderCharacters placeholderCharacters, @Nullable String prettyPrint,
             @Nullable Boolean generateNamespacedGrammar, @Nullable List<String> sdfMetaFile, @Nullable String externalDef,
             @Nullable Arguments sdfArgs, @Nullable StrategoBuildSetting buildSetting,
@@ -90,7 +91,7 @@ public class SpoofaxLanguageSpecConfig extends LanguageSpecConfig implements ISp
             @Nullable String externalJarFlags, @Nullable Arguments strategoArgs,
             @Nullable Collection<IBuildStepConfig> buildSteps) {
         super(config, projectConfig, id, name, sdfEnabled, sdf2tableVersion, checkOverlap, checkPriorities,
-                dataDependent, parseTable, completionsParseTable, jsglrVersion, jsglr2Logging, statixConcurrent,
+                dataDependent, parseTable, completionsParseTable, jsglrVersion, jsglr2Logging, statixMode,
                 langContribs, generates, exports, pardonedLanguages, useBuildSystemSpec);
         this.projectConfig = projectConfig;
 

--- a/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/config/SpoofaxLanguageSpecConfigBuilder.java
+++ b/org.metaborg.spoofax.meta.core/src/main/java/org/metaborg/spoofax/meta/core/config/SpoofaxLanguageSpecConfigBuilder.java
@@ -62,7 +62,7 @@ public class SpoofaxLanguageSpecConfigBuilder extends LanguageSpecConfigBuilder
         final SpoofaxLanguageSpecConfig config = new SpoofaxLanguageSpecConfig(configuration, projectConfig, identifier,
             name, langContribs, generates, exports, pardonedLanguages, useBuildSystemSpec, sdfVersion, sdfEnabled,
             sdf2tableVersion, checkOverlap, checkPriorities, dataDependent, sdfMainFile, parseTable, jsglrVersion,
-            jsglr2Logging, statixConcurrent, completionsParseTable, placeholderCharacters, prettyPrint,
+            jsglr2Logging, statixMode, completionsParseTable, placeholderCharacters, prettyPrint,
             generateNamespacedGrammar, sdfMetaFile, sdfExternalDef, sdfArgs, strBuildSetting,
             strFormat, strExternalJar, strExternalJarFlags, strArgs, buildSteps);
         return config;


### PR DESCRIPTION
This PR deprecates two configuration options.

The `language.statix.concurrent` language project configuration option is replaced by `language.statix.mode`, which (for now) can have three values (`traditional`, `concurrent` or `incremental-scopegraph-diff`, where the latter activates the first iteration of the incremental solver.).

The `runtime.statix.concurrent` example project configuration option is replaced by `runtime.statix.mode`, which (for now) can have four values (`traditional`, `concurrent`, `incremental-deadlock` or `incremental-scopegraph-diff`, where the latter two activate (part of) the first iteration of the incremental solver.).

To be merged together with metaborg/nabl#53