### PR TITLE
Fix ResourceService#localFile

### DIFF
--- a/org.metaborg.core/src/main/java/org/metaborg/core/resource/ResourceService.java
+++ b/org.metaborg.core/src/main/java/org/metaborg/core/resource/ResourceService.java
@@ -159,7 +159,7 @@ public class ResourceService implements IResourceService {
             }
             copyLoc.copyFrom(resource, new AllFileSelector());
 
-            return localDir;
+            return FileUtils.toFile(copyLoc);
         } catch(FileSystemException e) {
             throw new MetaborgRuntimeException("Could not get local file for " + resource, e);
         }


### PR DESCRIPTION
According to the docs it should return the local file, but it gave the local dir when it was copied to that dir. This fixes that.